### PR TITLE
Fix grok parse failure in AWS cloudtrail

### DIFF
--- a/config/processors/api_log_audit_aws.cloudtrail.conf
+++ b/config/processors/api_log_audit_aws.cloudtrail.conf
@@ -10,36 +10,36 @@ filter {
     source => "message"
     target => "aws"
   }
-  grok {
-    match => { "[aws][userIdentity][principalId]" => "(?<service.id>.*?):(?<service.name>.*?)$" }
+  if [aws][userIdentity][principalId]{
+	grok {
+      match => { "[aws][userIdentity][principalId]" => "(?<service.id>.*?):(?<service.name>.*?)$" }
+	  tag_on_failure => "grok1"
+	}
   }
-  grok {
-    match => { "[aws][userIdentity][arn]" => "^.*?:.*?:.*?:.*?:(?<cloud.instance.id>.*?):(?<cloud.instance.name>.*?)$" }
+  if [aws][userIdentity][arn]{
+	grok {
+	  match => { "[aws][userIdentity][arn]" => "^.*?:.*?:.*?:.*?:(?<cloud.instance.id>.*?):(?<cloud.instance.name>.*?)$" }
+	  tag_on_failure => "grok2"
+	}
   }
 
-  mutate {
-    remove_field => ["[aws][userIdentity][principalId]", "[aws][userIdentity][arn]"]
-  }
-  mutate {
-    add_field => {"log.source.hostname" => "api_aws_cloudtrail"}
-  }
   mutate {
     add_field => { "cloud.provider" => "aws" }
     add_field => { "event.module" => "aws.cloudtrail" }
     add_field => { "observer.vendor" => "aws" }
     add_field => { "observer.product" => "aws.cloudtrail" }
     add_field => { "observer.type" => "cloud logs" }
-    add_field => { "log.source.hostname" => "aws" }
+    add_field => {"log.source.hostname" => "api_aws_cloudtrail"}
     # base/common fields
     rename => { "[aws][eventVersion]" => "service.version" }
     rename => { "[aws][eventTime]" => "event.created" }
-    rename => { "[aws][eventSource]" => "event.dataset" }    
+    rename => { "[aws][eventSource]" => "event.dataset" }
     rename => { "[aws][eventName]" => "event.action" }
     rename => { "[aws][awsRegion]" => "cloud.region" }
     rename => { "[aws][recipientAccountId]" => "cloud.account.id" }
-    rename => { "[aws][sourceIPAddress]" => "source.ip" }   
-    rename => { "[aws][userAgent]" => "user_agent.name" }  
-    rename => { "[aws][requestID]" => "service.id" }
+    rename => { "[aws][sourceIPAddress]" => "source.ip" }
+    rename => { "[aws][userAgent]" => "user_agent.name" }
+    rename => { "[aws][requestID]" => "transaction.id" }
     rename => { "[aws][eventID]" => "event.id" }
     rename => { "[aws][eventType]" => "event.type" }
     rename => { "[aws][errorCode]" => "error.code" }
@@ -64,7 +64,7 @@ filter {
     rename => { "[aws][insightDetails][insightDuration]" => "event.duration" }
   }
   mutate {
-    remove_field => ["aws"]
+     remove_field => ["aws"]
   }
   if [source.ip] !~ "^(\d+\.\d+\.\d+\.\d+|[0-9a-zA-Z]+:.*?:.*?:.*?:.*?:.*?:.*?:[0-9a-zA-Z]+)$" {
     mutate {
@@ -81,9 +81,9 @@ filter {
     }
       fallback => "database"
   }
-    
+
   # event.created = "2020-12-15T15:23:30Z",
-  mutate { 
+  mutate {
     gsub => [
       "event.created", "T", " ",
       "event.created", "Z", ""
@@ -96,7 +96,7 @@ filter {
     target => "event.created"
     tag_on_failure => "_dateparsefailure_ec"
    }
-  
+
   if "_dateparsefailure_ec" in [tags]  {
     if ![log.original] {
       mutate {
@@ -107,9 +107,8 @@ filter {
      remove_field => ["event.created"]
     }
   }
-  
-  
 }
+
 output {
   pipeline { send_to => [enrichments] }
 }


### PR DESCRIPTION
## Description
Prior to this change, cloudtrail was failing on the second grok pattern, because userIdentity wasn't in every log. So there were conditionals added to check for whether this field exists, as well as in the first grok pattern too (principalId).

## XRefence issues
No

## Todos
NA