### PR TITLE
Erin verbeck lane mwg mcp alignment

### DIFF
--- a/config/processors/api_log_security_mcafee.mcp_v5.conf
+++ b/config/processors/api_log_security_mcafee.mcp_v5.conf
@@ -75,7 +75,19 @@ filter {
     add_field => { "observer.product" => "mcafee proxy logs" }
     add_field => { "observer.type" => "api" }
   }
-  
+  mutate {
+    lowercase => [ "event.action" ]
+  }
+  if [event.action] =~ "observed" {
+    mutate {
+      replace => { "event.action" => "allowed" }
+    }
+  }
+  if [event.action] =~ "denied" {
+    mutate {
+      replace => { "event.action" => "denied" }
+    }
+  }
 }
 output {
   pipeline { send_to => [enrichments] }

--- a/config/processors/syslog_log_security_mcafee.mwg.conf
+++ b/config/processors/syslog_log_security_mcafee.mwg.conf
@@ -64,14 +64,14 @@ filter {
       dissect {
         tag_on_failure => "_dissectfailure_4"
         mapping => {
-          rest_msg => "%{?data},%{?data},%{?data},%{event.action},%{?data},%{?data} ,%{user.name}, (%{source.ip}),%{?data},Severity: %{log.level}"
+          rest_msg => "%{?data},%{?data},%{?data},%{error.message},%{?data},%{?data} ,%{user.name}, (%{source.ip}),%{?data},Severity: %{log.level}"
         }
       }
     } else {
       dissect {
         tag_on_failure => "_dissectfailure_5"
         mapping => {
-          rest_msg => "%{?data},%{?data},%{?data},%{event.action},%{?data},%{rule.description},%{?data},Severity: %{log.level}"
+          rest_msg => "%{?data},%{?data},%{?data},%{event.reason},%{?data},%{error.message},%{?data},Severity: %{log.level}"
         }
       }
     }
@@ -121,13 +121,13 @@ filter {
 
   translate {
     field => "[rule.id]"
-    destination => "[event.action]"
+    destination => "[rule.description]"
     dictionary => {
       "0" => "Allowed"
       "1" => "Internal error"
       "2" => "Default message template being used for an action"
-      "3" => "Internal URL  error"
-      "10" => "Blocked due to an entry in the URL  database"
+      "3" => "Internal URL error"
+      "10" => "Blocked due to an entry in the URL database"
       "14" => "Blocked according to URL ing by expression"
       "15" => "Blocked by the Real-Time Classifier"
       "20" => "Blocked due to lack of content type"
@@ -165,6 +165,16 @@ filter {
       "400" => "Blocked due to an authorized override redirect"
     }
     fallback => "Others"
+  }
+  if [rule.description] =~ "Allowed" {
+    mutate {
+      add_field => { "event.action" => "allowed" }
+    }
+  }
+  if [rule.description] =~ "Blocked" {
+    mutate {
+      add_field => { "event.action" => "denied" }
+    }
   }
 }
 output {


### PR DESCRIPTION
## Description
Please provide a description of your proposed changes - providing obfuscated log/code examples is highly encouraged.
Given that Mcafee Cloud Proxy and Mcafee Web Gateway logs stem from the same vendor, we made the decision to have event.action align on the same two words: Allowed and Denied. Before, MCP's event.action said "Observed" or "Denied" and MWG said "Allowed" or "Blocked." By standardizing these two values, this enables cross-searching over both log sources.

## Related Issues
Are there any Issues to this PR? 
None I'm aware of.

## Todos
Are there any additional items that must be completed before this PR gets merged in?
- [ ] 
- [ ] 