### PR TITLE
syslog and api files were swapped, so I switched the filename back

### DIFF
--- a/config/processors/api_log_security_aws.guardduty.conf
+++ b/config/processors/api_log_security_aws.guardduty.conf
@@ -7,84 +7,155 @@ input {
 }
 filter {
   mutate {
-    add_field => {"log.source.hostname" => "api_aws_guardduty"}
-  }
-  mutate {
-    add_field => { "event.module" => "aws.guardduty.syslog" }
-    add_field => { "event.dataset" => "aws.guardduty" }
+    add_field => { "event.module" => "aws.guardduty" }
+    add_field => { "event.dataset" => "guardduty" }
     add_field => { "observer.vendor" => "aws" }
     add_field => { "observer.product" => "aws.guardduty" }
-    add_field => { "observer.type" => "logging" }
+    add_field => { "observer.type" => "cloud security alerts" }
   }
-### Header
-  ### Logstash tcp or udp in
-  if [agent.type] == "logstash" { 
-    grok {
-      tag_on_failure => "_parsefailure_header"
-      match => { "message" => "(\<(?<pri>\d+)\>( )?)?(?<rest_msg>.*?)$" }
+  json {
+    source => "message"
+    target => "guard"
+  }
+  mutate {
+    tag_on_failure => "mutate 1 failure"
+    rename => { "[guard][severity]" => "event.severity_name" }
+    rename => { "[guard][createdAt]" => "event.created" }
+    rename => { "[guard][updatedAt]" => "event.modified" }
+    rename => { "[guard][title]" => "rule.name" }
+    rename => { "[guard][description]" => "rule.description" }
+    rename => { "[guard][schemaVersion]" => "service.version" }
+    rename => { "[guard][accountId]" => "cloud.account.id" }
+    rename => { "[guard][region]" => "cloud.region" }
+    rename => { "[guard][partition]" => "cloud.provider" }
+    rename => { "[guard][id]" => "event.id" }
+    rename => { "[guard][type]" => "rule.ruleset" }
+    rename => { "[guard][resource][instanceDetails][availabilityZone]" => "cloud.availability_zone" }
+    rename => { "[guard][resource][instanceDetails][imageDescription]" => "container.image.name" }
+    rename => { "[guard][resource][instanceDetails][instanceId]" => "cloud.instance.id" }
+    rename => { "[guard][resource][instanceDetails][instanceState]" => "service.state" }
+    rename => { "[guard][resource][instanceDetails][instanceType]" => "cloud.machine.type" }
+    rename => { "[guard][resource][instanceDetails][networkInterfaces][subnetId]" => "network.name" }
+    rename => { "[guard][resource][instanceDetails][networkInterfaces][securityGroups][groupName]" => "user.group.name" }
+    rename => { "[guard][resource][instanceDetails][networkInterfaces][securityGroups][groupId]" => "user.group.id" }
+    rename => { "[guard][resource][accessKeyDetails][userName]" => "user.name" }
+    rename => { "[service][action][awsApiCallAction][remoteIpDetails][organization][asn]" => "source.as.number" }
+    rename => { "[service][action][awsApiCallAction][remoteIpDetails][organization][asnOrg]" => "source.as.organization.name" }
+    rename => { "[service][action][awsApiCallAction][remoteIpDetails][ipAddressV4]" => "source.ip" }
+    rename => { "[service][action][awsApiCallAction][serviceName]" => "service.name" }
+    rename => { "[service][action][actionType]" => "rule.category" }
+    rename => { "[service][action][portProbeAction][portProbeDetails][localPortDetails][port]" => "destination.port"	}
+    rename => { "[service][detectorId]" => "rule.id" }
+    rename => { "[service][eventFirstSeen]" => "event.start" }
+    rename => { "[service][eventLastSeen]" => "event.end" }
+  }
+  if [service][action][portProbeAction][blocked] == "false" {
+    mutate {
+      tag_on_failure => "mutate 2 failure"
+      add_field => { "event.action" => "allow" }
     }
   } else {
-  ### Filebeats udp or tcp in
-    grok {
-      tag_on_failure => "_parsefailure_header"
-      match => { "message" => ".*?\{name=.*?\} (\<(?<pri>\d+)\>( )?)?(?<rest_msg>.*?)$" }
+    mutate {
+      tag_on_failure => "mutate 3 failure"
+      add_field => { "event.action" => "blocked" }
     }
-  }
-  syslog_pri {
-    syslog_pri_field_name => "pri"
   }
 
   mutate {
-    strip => ["message"]
+    tag_on_failure => "mutate 4 failure"
+    gsub => [
+      "event.created", "T", " ",
+      "event.modified", "T", " ",
+      "event.start", "T", " ",
+      "event.end", "T", " ",
+      "event.created", "Z", "",
+      "event.modified", "Z", "",
+      "event.start", "Z", "",
+      "event.end", "Z", ""
+    ]
   }
-  if [rest_msg] =~ "{" {
+### "event.created " = "2020-12-23T16:58:11.845Z",
+ date {
+      match => ["event.created","yyyy-MM-dd HH:mm:ss.SSS"]
+      timezone => "GMT"
+      locale => "en"
+      target => "event.created"
+      tag_on_failure => "_dateparsefailure_ec"
+  }
+  if "_dateparsefailure_ec" in [tags]  {
+      if ![log.original] {
     mutate {
-      add_field => { "agent.parse_rule" => "RULE 1" }
+        copy => { "message" => "log.original" }
+      }
     }
     mutate {
-    # remove the last occurence of }
-      strip => ["rest_msg"]
-      gsub => ["rest_msg", "[}](?=[^}]*$)", "" ]
-      update => {"rest_msg" => "%{rest_msg}"}
-      gsub => ["rest_msg", "[{](?=[^{]*$)", "" ]
-      update => {"rest_msg" => "%{rest_msg}"}
-      gsub => ["rest_msg","[{]", ""]
-      gsub => ["rest_msg","[']", ""]
-    }
-    kv {
-      source => "rest_msg"
-      field_split => ","
-      value_split => ":"
-      target => "guard"
+      remove_field => ["event.created"]
     }
   }
-  mutate {
-    rename => {"[guard][ alerttype]" => "rule.name"}
-    rename => {"[guard][ type]" => "rule.category"}
-    rename => {"[guard][ link]" => "rule.reference"}
-    rename => {"[guard][ accountid]" => "cloud.account.id"}
-    rename => {"[guard][ region]" => "cloud.availability_zone"}
-    rename => {"[guard][ username]" => "user.name"}
-    rename => {"[guard][ source]" => "source.ip"}
-    rename => {"[guard][ destination]" => "destination.ip"}
-    rename => {"[guard][ severity]" => "event.severity"}
+### "event.modified" = "2020-12-23T16:58:11.845Z",
+   date {
+      match => ["event.modified","yyyy-MM-dd HH:mm:ss.SSS"]
+      timezone => "GMT"
+      locale => "en"
+      target => "event.modified"
+      tag_on_failure => "_dateparsefailure_em"
   }
-  mutate {
-	  lowercase => [ "rule.name" ]
-  }
-  mutate {
-    remove_field => ["rest_msg","log.date","[guard]","tmp", "pri"]
-  }
-  translate {
-    field => "[event.severity_name]"
-    destination => "[rule.category]"
-    dictionary => {
-      "ERRR" => "Security/Vulnerability"
-      "INFO" => "Security/Activity"
-      "NOTE" => "Security/Other"
-      "WARN" => "Security/Warning"
+  if "_dateparsefailure_em" in [tags]  {
+      if ![log.original] {
+        mutate {
+          tag_on_failure => "mutate 5 failure"
+          copy => { "message" => "log.original" }
+        }
+      }
+    mutate {
+      tag_on_failure => "mutate 6 failure"
+      remove_field => ["event.modified"]
     }
-      fallback => "Others"
+  }
+  # "event.start" = 2019-10-23T01:14:26Z
+   date {
+      match => ["event.start","yyyy-MM-dd HH:mm:ss.SSS"]
+      timezone => "GMT"
+      locale => "en"
+      target => "event.start"
+      tag_on_failure => "_dateparsefailure_es"
+  }
+  if "_dateparsefailure_es" in [tags]  {
+      if ![log.original] {
+    mutate {
+        tag_on_failure => "mutate 7 failure"
+        copy => { "message" => "log.original" }
+      }
+    }
+    mutate {
+      tag_on_failure => "mutate 8 failure"
+      remove_field => ["event.start"]
+    }
+  }
+  ### "event.end" = 2021-01-08T11:55:26Z
+   date {
+      match => ["event.end","yyyy-MM-dd HH:mm:ss.Z"]
+      timezone => "GMT"
+      locale => "en"
+      target => "event.end"
+      tag_on_failure => "_dateparsefailure_ee"
+  }
+  if "_dateparsefailure_ee" in [tags]  {
+      if ![log.original] {
+        mutate {
+          tag_on_failure => "mutate 9 failure"
+          copy => { "message" => "log.original" }
+        }
+      }
+    mutate {
+      tag_on_failure => "mutate 10 failure"
+      remove_field => ["event.end"]
+    }
+  }
+
+  mutate {
+    tag_on_failure => "mutate 11 failure"
+    remove_field => ["guard"]
   }
 }
 output {

--- a/config/processors/syslog_log_security_aws.guardduty.conf
+++ b/config/processors/syslog_log_security_aws.guardduty.conf
@@ -7,155 +7,84 @@ input {
 }
 filter {
   mutate {
-    add_field => { "event.module" => "aws.guardduty" }
-    add_field => { "event.dataset" => "guardduty" }
+    add_field => {"log.source.hostname" => "api_aws_guardduty"}
+  }
+  mutate {
+    add_field => { "event.module" => "aws.guardduty.syslog" }
+    add_field => { "event.dataset" => "aws.guardduty" }
     add_field => { "observer.vendor" => "aws" }
     add_field => { "observer.product" => "aws.guardduty" }
-    add_field => { "observer.type" => "cloud security alerts" }
+    add_field => { "observer.type" => "logging" }
   }
-  json {
-    source => "message"
-    target => "guard"
-  }
-  mutate {
-    tag_on_failure => "mutate 1 failure"
-    rename => { "[guard][severity]" => "event.severity_name" }
-    rename => { "[guard][createdAt]" => "event.created" }
-    rename => { "[guard][updatedAt]" => "event.modified" }
-    rename => { "[guard][title]" => "rule.name" }
-    rename => { "[guard][description]" => "rule.description" }
-    rename => { "[guard][schemaVersion]" => "service.version" }
-    rename => { "[guard][accountId]" => "cloud.account.id" }
-    rename => { "[guard][region]" => "cloud.region" }
-    rename => { "[guard][partition]" => "cloud.provider" }
-    rename => { "[guard][id]" => "event.id" }
-    rename => { "[guard][type]" => "rule.ruleset" }
-    rename => { "[guard][resource][instanceDetails][availabilityZone]" => "cloud.availability_zone" }
-    rename => { "[guard][resource][instanceDetails][imageDescription]" => "container.image.name" }
-    rename => { "[guard][resource][instanceDetails][instanceId]" => "cloud.instance.id" }
-    rename => { "[guard][resource][instanceDetails][instanceState]" => "service.state" }
-    rename => { "[guard][resource][instanceDetails][instanceType]" => "cloud.machine.type" }
-    rename => { "[guard][resource][instanceDetails][networkInterfaces][subnetId]" => "network.name" }
-    rename => { "[guard][resource][instanceDetails][networkInterfaces][securityGroups][groupName]" => "user.group.name" }
-    rename => { "[guard][resource][instanceDetails][networkInterfaces][securityGroups][groupId]" => "user.group.id" }
-    rename => { "[guard][resource][accessKeyDetails][userName]" => "user.name" }
-    rename => { "[service][action][awsApiCallAction][remoteIpDetails][organization][asn]" => "source.as.number" }
-    rename => { "[service][action][awsApiCallAction][remoteIpDetails][organization][asnOrg]" => "source.as.organization.name" }
-    rename => { "[service][action][awsApiCallAction][remoteIpDetails][ipAddressV4]" => "source.ip" }
-    rename => { "[service][action][awsApiCallAction][serviceName]" => "service.name" }
-    rename => { "[service][action][actionType]" => "rule.category" }
-    rename => { "[service][action][portProbeAction][portProbeDetails][localPortDetails][port]" => "destination.port"	}
-    rename => { "[service][detectorId]" => "rule.id" }
-    rename => { "[service][eventFirstSeen]" => "event.start" }
-    rename => { "[service][eventLastSeen]" => "event.end" }
-  }
-  if [service][action][portProbeAction][blocked] == "false" {
-    mutate {
-      tag_on_failure => "mutate 2 failure"
-      add_field => { "event.action" => "allow" }
+### Header
+  ### Logstash tcp or udp in
+  if [agent.type] == "logstash" { 
+    grok {
+      tag_on_failure => "_parsefailure_header"
+      match => { "message" => "(\<(?<pri>\d+)\>( )?)?(?<rest_msg>.*?)$" }
     }
   } else {
-    mutate {
-      tag_on_failure => "mutate 3 failure"
-      add_field => { "event.action" => "blocked" }
+  ### Filebeats udp or tcp in
+    grok {
+      tag_on_failure => "_parsefailure_header"
+      match => { "message" => ".*?\{name=.*?\} (\<(?<pri>\d+)\>( )?)?(?<rest_msg>.*?)$" }
     }
+  }
+  syslog_pri {
+    syslog_pri_field_name => "pri"
   }
 
   mutate {
-    tag_on_failure => "mutate 4 failure"
-    gsub => [
-      "event.created", "T", " ",
-      "event.modified", "T", " ",
-      "event.start", "T", " ",
-      "event.end", "T", " ",
-      "event.created", "Z", "",
-      "event.modified", "Z", "",
-      "event.start", "Z", "",
-      "event.end", "Z", ""
-    ]
+    strip => ["message"]
   }
-### "event.created " = "2020-12-23T16:58:11.845Z",
- date {
-      match => ["event.created","yyyy-MM-dd HH:mm:ss.SSS"]
-      timezone => "GMT"
-      locale => "en"
-      target => "event.created"
-      tag_on_failure => "_dateparsefailure_ec"
-  }
-  if "_dateparsefailure_ec" in [tags]  {
-      if ![log.original] {
+  if [rest_msg] =~ "{" {
     mutate {
-        copy => { "message" => "log.original" }
-      }
+      add_field => { "agent.parse_rule" => "RULE 1" }
     }
     mutate {
-      remove_field => ["event.created"]
+    # remove the last occurence of }
+      strip => ["rest_msg"]
+      gsub => ["rest_msg", "[}](?=[^}]*$)", "" ]
+      update => {"rest_msg" => "%{rest_msg}"}
+      gsub => ["rest_msg", "[{](?=[^{]*$)", "" ]
+      update => {"rest_msg" => "%{rest_msg}"}
+      gsub => ["rest_msg","[{]", ""]
+      gsub => ["rest_msg","[']", ""]
+    }
+    kv {
+      source => "rest_msg"
+      field_split => ","
+      value_split => ":"
+      target => "guard"
     }
   }
-### "event.modified" = "2020-12-23T16:58:11.845Z",
-   date {
-      match => ["event.modified","yyyy-MM-dd HH:mm:ss.SSS"]
-      timezone => "GMT"
-      locale => "en"
-      target => "event.modified"
-      tag_on_failure => "_dateparsefailure_em"
-  }
-  if "_dateparsefailure_em" in [tags]  {
-      if ![log.original] {
-        mutate {
-          tag_on_failure => "mutate 5 failure"
-          copy => { "message" => "log.original" }
-        }
-      }
-    mutate {
-      tag_on_failure => "mutate 6 failure"
-      remove_field => ["event.modified"]
-    }
-  }
-  # "event.start" = 2019-10-23T01:14:26Z
-   date {
-      match => ["event.start","yyyy-MM-dd HH:mm:ss.SSS"]
-      timezone => "GMT"
-      locale => "en"
-      target => "event.start"
-      tag_on_failure => "_dateparsefailure_es"
-  }
-  if "_dateparsefailure_es" in [tags]  {
-      if ![log.original] {
-    mutate {
-        tag_on_failure => "mutate 7 failure"
-        copy => { "message" => "log.original" }
-      }
-    }
-    mutate {
-      tag_on_failure => "mutate 8 failure"
-      remove_field => ["event.start"]
-    }
-  }
-  ### "event.end" = 2021-01-08T11:55:26Z
-   date {
-      match => ["event.end","yyyy-MM-dd HH:mm:ss.Z"]
-      timezone => "GMT"
-      locale => "en"
-      target => "event.end"
-      tag_on_failure => "_dateparsefailure_ee"
-  }
-  if "_dateparsefailure_ee" in [tags]  {
-      if ![log.original] {
-        mutate {
-          tag_on_failure => "mutate 9 failure"
-          copy => { "message" => "log.original" }
-        }
-      }
-    mutate {
-      tag_on_failure => "mutate 10 failure"
-      remove_field => ["event.end"]
-    }
-  }
-
   mutate {
-    tag_on_failure => "mutate 11 failure"
-    remove_field => ["guard"]
+    rename => {"[guard][ alerttype]" => "rule.name"}
+    rename => {"[guard][ type]" => "rule.category"}
+    rename => {"[guard][ link]" => "rule.reference"}
+    rename => {"[guard][ accountid]" => "cloud.account.id"}
+    rename => {"[guard][ region]" => "cloud.availability_zone"}
+    rename => {"[guard][ username]" => "user.name"}
+    rename => {"[guard][ source]" => "source.ip"}
+    rename => {"[guard][ destination]" => "destination.ip"}
+    rename => {"[guard][ severity]" => "event.severity"}
+  }
+  mutate {
+	  lowercase => [ "rule.name" ]
+  }
+  mutate {
+    remove_field => ["rest_msg","log.date","[guard]","tmp", "pri"]
+  }
+  translate {
+    field => "[event.severity_name]"
+    destination => "[rule.category]"
+    dictionary => {
+      "ERRR" => "Security/Vulnerability"
+      "INFO" => "Security/Activity"
+      "NOTE" => "Security/Other"
+      "WARN" => "Security/Warning"
+    }
+      fallback => "Others"
   }
 }
 output {


### PR DESCRIPTION
## Description
Please provide a description of your proposed changes - providing obfuscated log/code examples is highly encouraged.
The content of the syslog guardduty file is meant to parse API-collected logs, and the content of the api guardduty file is meant to parse syslog-collected logs. I am flipping around the filenames.

## Related Issues
Are there any Issues to this PR? 
N/A

## Todos
Are there any additional items that must be completed before this PR gets merged in?
N/A