### PR TITLE
nessus: changed dissect to grok to while addressing failure tags; added initial parsing for 'not parsed' tagged logs

### DIFF
--- a/config/processors/syslog_log_audit_tenable.nessus_scanner.conf
+++ b/config/processors/syslog_log_audit_tenable.nessus_scanner.conf
@@ -175,7 +175,7 @@ filter {
     }
   }
   mutate {
-    remove_field => [ "ns", "rest_msg", "tmp" ]
+    remove_field => ["ns", "rest_msg", "tmp"]
   }
 }
 output {

--- a/config/processors/syslog_log_audit_tenable.nessus_scanner.conf
+++ b/config/processors/syslog_log_audit_tenable.nessus_scanner.conf
@@ -175,7 +175,7 @@ filter {
     }
   }
   mutate {
-    remove_field => ["ns"]
+    remove_field => ["ns", "rest_msg", "tmp"]
   }
 }
 output {

--- a/config/processors/syslog_log_audit_tenable.nessus_scanner.conf
+++ b/config/processors/syslog_log_audit_tenable.nessus_scanner.conf
@@ -123,7 +123,7 @@ filter {
       dissect {
           tag_on_failure => "_dissectfailure_4"
           mapping => {
-            "[ns][name]" => "%{file.uid}/%{process.entity_id}"
+            "[ns][name]" => "%{file.uid}/Chunk %{process.entity_id}."
           }
         }
     }

--- a/config/processors/syslog_log_audit_tenable.nessus_scanner.conf
+++ b/config/processors/syslog_log_audit_tenable.nessus_scanner.conf
@@ -44,12 +44,12 @@ filter {
       }
       if [rest_msg] =~ "received signal" {
         mutate {
-          add_field => { "event.action" => "SC Service stopped" }
+          add_field => { "event.action" => "Nessus Service stopped" }
         }
       }
       else {
         mutate {
-          add_field => { "event.action" => "SC Service started back up and running" }
+          add_field => { "event.action" => "Nessus Service started back up and running" }
         }
       }
     }
@@ -153,18 +153,9 @@ filter {
     }
   }
   else {
-    dissect {
-      tag_on_failure => "_dissectfailure_5"
-      mapping => {
-        "rest_msg" => "%{?data->} %{?data} %{?data} %{host.hostname} %{?data}: %{rule.description}"
-      }
-    }
-  }
-  if "_dissectfailure_5" in [tags] {
     mutate {
       copy => { "message" => "log.original" }
       add_tag => ["unparsed"]
-      remove_tag => [ "_dissectfailure_5" ]
     }
   }
   if "_dissectfailure" in [tags] {

--- a/config/processors/syslog_log_audit_tenable.nessus_scanner.conf
+++ b/config/processors/syslog_log_audit_tenable.nessus_scanner.conf
@@ -31,7 +31,7 @@ filter {
   mutate {
     remove_field => ["pri"]
   }
-  if [rest_msg] =~ "call stack" or "-----" in [rest_msg] or "# ()" in [rest_msg] or "# recv()" in [rest_msg] {
+  if [rest_msg] =~ "call stack|-----|# ()|# recv()|# ???()|# bpf_next()" {
     drop {}
   }
   if [rest_msg] =~ "t.nessuscore|T.NessusCore" {
@@ -54,10 +54,9 @@ filter {
       }
     }
     else {
-      dissect {
-        tag_on_failure => "_dissectfailure"
-        mapping => {
-          "rest_msg" => "%{?data->} %{?data} %{?data} %{host.hostname} %{?data} [%{?data} %{event.start}][%{?data}][%{tmp} : %{rule.description}"
+      grok {
+        match => {
+          "rest_msg" => "(.*?) (.*) (?<host.hostname>.*) (T.NessusCore)?(t.nessuscore)? \[(.*?) (?<event.start>.*?)\]\[(.*?)\]\[(?<tmp>.*?)( )?\:( )?(?<rule.description>.*)"
         }
       }
     }
@@ -114,6 +113,7 @@ filter {
     }
     mutate {
       rename => {"[ns][target]" => "destination.address"}
+      rename => {"[ns][port]" => "destination.port"}
       rename => {"[ns][pid]" => "process.pid"}
       rename => {"[ns][scan]" => "event.id"}
       rename => {"[ns][duration]" => "event.duration"}
@@ -153,9 +153,18 @@ filter {
     }
   }
   else {
+    dissect {
+      tag_on_failure => "_dissectfailure_5"
+      mapping => {
+        "rest_msg" => "%{?data->} %{?data} %{?data} %{host.hostname} %{?data}: %{rule.description}"
+      }
+    }
+  }
+  if "_dissectfailure_5" in [tags] {
     mutate {
       copy => { "message" => "log.original" }
       add_tag => ["unparsed"]
+      remove_tag => [ "_dissectfailure_5" ]
     }
   }
   if "_dissectfailure" in [tags] {
@@ -166,7 +175,7 @@ filter {
     }
   }
   mutate {
-    remove_field => ["ns", "rest_msg", "tmp"]
+    remove_field => ["ns"]
   }
 }
 output {

--- a/config/processors/syslog_log_audit_tenable.nessus_scanner.conf
+++ b/config/processors/syslog_log_audit_tenable.nessus_scanner.conf
@@ -175,7 +175,7 @@ filter {
     }
   }
   mutate {
-    remove_field => ["ns", "rest_msg", "tmp"]
+    remove_field => [ "ns", "rest_msg", "tmp" ]
   }
 }
 output {


### PR DESCRIPTION
## Description
1. Karthik said that no parsing is needed for logs which we added tag as "not parsed" (the ones which doesnt have 't.nessuscore|T.NessusCore' - so the initial parsing which I have added in first commit is removed later
2. Changed 'SC' to 'Nessus' in event.action
3. Removed 'chunk' from process.entity_id


## Related Issues
Are there any Issues to this PR? 
No

## Todos
NA 