### PR TITLE
400 error fix in azure event hub tcs and atp files

### DIFF
--- a/config/processors/event_hub_log_security_azure.event_hub.conf
+++ b/config/processors/event_hub_log_security_azure.event_hub.conf
@@ -50,7 +50,7 @@ filter {
 
     rename => {"[tcs][callerIpAddress]" => "source.ip"}
     rename => {"[tcs][category]" => "rule.category"}
-    rename => {"[tcs][location]" => "host.geo.location"}
+    rename => {"[tcs][location]" => "host.geo.name"}
     rename => {"[tcs][time]" => "event.start"}
 
     rename => {"[tcs][operationVersion]" => "host.os.version"}

--- a/config/processors/event_hub_log_security_azure.event_hub_atp.conf
+++ b/config/processors/event_hub_log_security_azure.event_hub_atp.conf
@@ -118,9 +118,9 @@ filter {
         copy => { "message" => "log.original" }
       }
     }
-    mutate {
-      remove_field => ["process.start", "az"]
-    }
+  }
+  mutate {
+    remove_field => ["process.start", "az"]
   }
 }
 output {


### PR DESCRIPTION
## Description
- azure.event_hub_atp: moved 'remove_filed' out of if conditional ( as it is never hitting that date if filter )
- azure.event_hub (tcs): renamed 'host.geo.location' to 'host.geo.name' as the value we are getting for that field is "string" (ex. EastUS)


## Related Issues
No


## Todos
NA