### PR TITLE
add in new ECS 1.11 CSV with custom fields

### DIFF
--- a/doc/elastic_common_schema/ecs_1.11_with_custom_fields.csv
+++ b/doc/elastic_common_schema/ecs_1.11_with_custom_fields.csv
@@ -1,0 +1,1248 @@
+﻿ECS_Version,Indexed,Field_Set,Field,Type,Level,Normalization,Example,Description
+1.11.0-dev,TRUE,base,@timestamp,date,core,,2016-05-23T08:05:34.853Z,Date/time when the event originated.
+1.11.0-dev,TRUE,base,labels,object,core,,"{""application"": ""foo-bar"", ""env"": ""production""}",Custom key/value pairs.
+1.11.0-dev,TRUE,base,message,text,core,,Hello World,Log message optimized for viewing in a log viewer.
+1.11.0-dev,TRUE,base,tags,keyword,core,array,"[""production"", ""env2""]",List of keywords used to tag each event.
+1.11.0-dev,TRUE,agent,agent.build.original,keyword,core,,"metricbeat version 7.6.0 (amd64), libbeat 7.6.0 [6a23e8f8f30f5001ba344e4e54d8d9cb82cb107c built 2020-02-05 23:10:10 +0000 UTC]",Extended build information for the agent.
+1.11.0-dev,TRUE,agent,agent.ephemeral_id,keyword,extended,,8a4f500f,Ephemeral identifier of this agent.
+1.11.0-dev,TRUE,agent,agent.id,keyword,core,,8a4f500d,Unique identifier of this agent.
+1.11.0-dev,TRUE,agent,agent.name,keyword,core,,foo,Custom name of the agent.
+1.11.0-dev,TRUE,agent,agent.type,keyword,core,,filebeat,Type of the agent.
+1.11.0-dev,TRUE,agent,agent.version,keyword,core,,6.0.0-rc2,Version of the agent.
+1.11.0-dev,TRUE,client,client.address,keyword,extended,,,Client network address.
+1.11.0-dev,TRUE,client,client.as.number,long,extended,,15169,Unique number allocated to the autonomous system.
+1.11.0-dev,TRUE,client,client.as.organization.name,keyword,extended,,Google LLC,Organization name.
+1.11.0-dev,TRUE,client,client.as.organization.name.text,text,extended,,Google LLC,Organization name.
+1.11.0-dev,TRUE,client,client.bytes,long,core,,184,Bytes sent from the client to the server.
+1.11.0-dev,TRUE,client,client.domain,keyword,core,,,Client domain.
+1.11.0-dev,TRUE,client,client.geo.city_name,keyword,core,,Montreal,City name.
+1.11.0-dev,TRUE,client,client.geo.continent_code,keyword,core,,NA,Continent code.
+1.11.0-dev,TRUE,client,client.geo.continent_name,keyword,core,,North America,Name of the continent.
+1.11.0-dev,TRUE,client,client.geo.country_iso_code,keyword,core,,CA,Country ISO code.
+1.11.0-dev,TRUE,client,client.geo.country_name,keyword,core,,Canada,Country name.
+1.11.0-dev,TRUE,client,client.geo.location,geo_point,core,,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
+1.11.0-dev,TRUE,client,client.geo.name,keyword,extended,,boston-dc,User-defined description of a location.
+1.11.0-dev,TRUE,client,client.geo.postal_code,keyword,core,,94040,Postal code.
+1.11.0-dev,TRUE,client,client.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
+1.11.0-dev,TRUE,client,client.geo.region_name,keyword,core,,Quebec,Region name.
+1.11.0-dev,TRUE,client,client.geo.timezone,keyword,core,,America/Argentina/Buenos_Aires,Time zone.
+1.11.0-dev,TRUE,client,client.ip,ip,core,,,IP address of the client.
+1.11.0-dev,TRUE,client,client.mac,keyword,core,,00-00-5E-00-53-23,MAC address of the client.
+1.11.0-dev,TRUE,client,client.nat.ip,ip,extended,,,Client NAT ip address
+1.11.0-dev,TRUE,client,client.nat.port,long,extended,,,Client NAT port
+1.11.0-dev,TRUE,client,client.packets,long,core,,12,Packets sent from the client to the server.
+1.11.0-dev,TRUE,client,client.port,long,core,,,Port of the client.
+1.11.0-dev,TRUE,client,client.registered_domain,keyword,extended,,example.com,"The highest registered client domain, stripped of the subdomain."
+1.11.0-dev,TRUE,client,client.subdomain,keyword,extended,,east,The subdomain of the domain.
+1.11.0-dev,TRUE,client,client.top_level_domain,keyword,extended,,co.uk,"The effective top level domain (com, org, net, co.uk)."
+1.11.0-dev,TRUE,client,client.user.domain,keyword,extended,,,Name of the directory the user is a member of.
+1.11.0-dev,TRUE,client,client.user.email,keyword,extended,,,User email address.
+1.11.0-dev,TRUE,client,client.user.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
+1.11.0-dev,TRUE,client,client.user.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
+1.11.0-dev,TRUE,client,client.user.group.domain,keyword,extended,,,Name of the directory the group is a member of.
+1.11.0-dev,TRUE,client,client.user.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
+1.11.0-dev,TRUE,client,client.user.group.name,keyword,extended,,,Name of the group.
+1.11.0-dev,TRUE,client,client.user.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
+1.11.0-dev,TRUE,client,client.user.id,keyword,core,,,Unique identifier of the user.
+1.11.0-dev,TRUE,client,client.user.name,keyword,core,,albert,Short name or login of the user.
+1.11.0-dev,TRUE,client,client.user.name.text,text,core,,albert,Short name or login of the user.
+1.11.0-dev,TRUE,client,client.user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
+1.11.0-dev,TRUE,cloud,cloud.account.id,keyword,extended,,6.67E+11,The cloud account or organization id.
+1.11.0-dev,TRUE,cloud,cloud.account.name,keyword,extended,,elastic-dev,The cloud account name.
+1.11.0-dev,TRUE,cloud,cloud.availability_zone,keyword,extended,,us-east-1c,"Availability zone in which this host, resource, or service is located."
+1.11.0-dev,TRUE,cloud,cloud.instance.id,keyword,extended,,i-1234567890abcdef0,Instance ID of the host machine.
+1.11.0-dev,TRUE,cloud,cloud.instance.name,keyword,extended,,,Instance name of the host machine.
+1.11.0-dev,TRUE,cloud,cloud.machine.type,keyword,extended,,t2.medium,Machine type of the host machine.
+1.11.0-dev,TRUE,cloud,cloud.project.id,keyword,extended,,my-project,The cloud project id.
+1.11.0-dev,TRUE,cloud,cloud.project.name,keyword,extended,,my project,The cloud project name.
+1.11.0-dev,TRUE,cloud,cloud.provider,keyword,extended,,aws,Name of the cloud provider.
+1.11.0-dev,TRUE,cloud,cloud.region,keyword,extended,,us-east-1,"Region in which this host, resource, or service is located."
+1.11.0-dev,TRUE,cloud,cloud.service.name,keyword,extended,,lambda,The cloud service name.
+1.11.0-dev,TRUE,container,container.id,keyword,core,,,Unique container id.
+1.11.0-dev,TRUE,container,container.image.name,keyword,extended,,,Name of the image the container was built on.
+1.11.0-dev,TRUE,container,container.image.tag,keyword,extended,array,,Container image tags.
+1.11.0-dev,TRUE,container,container.labels,object,extended,,,Image labels.
+1.11.0-dev,TRUE,container,container.name,keyword,extended,,,Container name.
+1.11.0-dev,TRUE,container,container.runtime,keyword,extended,,docker,Runtime managing this container.
+1.11.0-dev,TRUE,data_stream,data_stream.dataset,constant_keyword,extended,,nginx.access,The field can contain anything that makes sense to signify the source of the data.
+1.11.0-dev,TRUE,data_stream,data_stream.namespace,constant_keyword,extended,,production,A user defined namespace. Namespaces are useful to allow grouping of data.
+1.11.0-dev,TRUE,data_stream,data_stream.type,constant_keyword,extended,,logs,An overarching type for the data stream.
+1.11.0-dev,TRUE,destination,destination.address,keyword,extended,,,Destination network address.
+1.11.0-dev,TRUE,destination,destination.as.number,long,extended,,15169,Unique number allocated to the autonomous system.
+1.11.0-dev,TRUE,destination,destination.as.organization.name,keyword,extended,,Google LLC,Organization name.
+1.11.0-dev,TRUE,destination,destination.as.organization.name.text,text,extended,,Google LLC,Organization name.
+1.11.0-dev,TRUE,destination,destination.bytes,long,core,,184,Bytes sent from the destination to the source.
+1.11.0-dev,TRUE,destination,destination.domain,keyword,core,,,Destination domain.
+1.11.0-dev,TRUE,destination,destination.geo.city_name,keyword,core,,Montreal,City name.
+1.11.0-dev,TRUE,destination,destination.geo.continent_code,keyword,core,,NA,Continent code.
+1.11.0-dev,TRUE,destination,destination.geo.continent_name,keyword,core,,North America,Name of the continent.
+1.11.0-dev,TRUE,destination,destination.geo.country_iso_code,keyword,core,,CA,Country ISO code.
+1.11.0-dev,TRUE,destination,destination.geo.country_name,keyword,core,,Canada,Country name.
+1.11.0-dev,TRUE,destination,destination.geo.location,geo_point,core,,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
+1.11.0-dev,TRUE,destination,destination.geo.name,keyword,extended,,boston-dc,User-defined description of a location.
+1.11.0-dev,TRUE,destination,destination.geo.postal_code,keyword,core,,94040,Postal code.
+1.11.0-dev,TRUE,destination,destination.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
+1.11.0-dev,TRUE,destination,destination.geo.region_name,keyword,core,,Quebec,Region name.
+1.11.0-dev,TRUE,destination,destination.geo.timezone,keyword,core,,America/Argentina/Buenos_Aires,Time zone.
+1.11.0-dev,TRUE,destination,destination.ip,ip,core,,,IP address of the destination.
+1.11.0-dev,TRUE,destination,destination.mac,keyword,core,,00-00-5E-00-53-23,MAC address of the destination.
+1.11.0-dev,TRUE,destination,destination.nat.ip,ip,extended,,,Destination NAT ip
+1.11.0-dev,TRUE,destination,destination.nat.port,long,extended,,,Destination NAT Port
+1.11.0-dev,TRUE,destination,destination.packets,long,core,,12,Packets sent from the destination to the source.
+1.11.0-dev,TRUE,destination,destination.port,long,core,,,Port of the destination.
+1.11.0-dev,TRUE,destination,destination.registered_domain,keyword,extended,,example.com,"The highest registered destination domain, stripped of the subdomain."
+1.11.0-dev,TRUE,destination,destination.subdomain,keyword,extended,,east,The subdomain of the domain.
+1.11.0-dev,TRUE,destination,destination.top_level_domain,keyword,extended,,co.uk,"The effective top level domain (com, org, net, co.uk)."
+1.11.0-dev,TRUE,destination,destination.user.domain,keyword,extended,,,Name of the directory the user is a member of.
+1.11.0-dev,TRUE,destination,destination.user.email,keyword,extended,,,User email address.
+1.11.0-dev,TRUE,destination,destination.user.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
+1.11.0-dev,TRUE,destination,destination.user.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
+1.11.0-dev,TRUE,destination,destination.user.group.domain,keyword,extended,,,Name of the directory the group is a member of.
+1.11.0-dev,TRUE,destination,destination.user.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
+1.11.0-dev,TRUE,destination,destination.user.group.name,keyword,extended,,,Name of the group.
+1.11.0-dev,TRUE,destination,destination.user.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
+1.11.0-dev,TRUE,destination,destination.user.id,keyword,core,,,Unique identifier of the user.
+1.11.0-dev,TRUE,destination,destination.user.name,keyword,core,,albert,Short name or login of the user.
+1.11.0-dev,TRUE,destination,destination.user.name.text,text,core,,albert,Short name or login of the user.
+1.11.0-dev,TRUE,destination,destination.user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
+1.11.0-dev,TRUE,dll,dll.code_signature.exists,boolean,core,,TRUE,Boolean to capture if a signature is present.
+1.11.0-dev,TRUE,dll,dll.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
+1.11.0-dev,TRUE,dll,dll.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
+1.11.0-dev,TRUE,dll,dll.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
+1.11.0-dev,TRUE,dll,dll.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
+1.11.0-dev,TRUE,dll,dll.code_signature.trusted,boolean,extended,,TRUE,Stores the trust status of the certificate chain.
+1.11.0-dev,TRUE,dll,dll.code_signature.valid,boolean,extended,,TRUE,Boolean to capture if the digital signature is verified against the binary content.
+1.11.0-dev,TRUE,dll,dll.hash.md5,keyword,extended,,,MD5 hash.
+1.11.0-dev,TRUE,dll,dll.hash.sha1,keyword,extended,,,SHA1 hash.
+1.11.0-dev,TRUE,dll,dll.hash.sha256,keyword,extended,,,SHA256 hash.
+1.11.0-dev,TRUE,dll,dll.hash.sha512,keyword,extended,,,SHA512 hash.
+1.11.0-dev,TRUE,dll,dll.hash.ssdeep,keyword,extended,,,SSDEEP hash.
+1.11.0-dev,TRUE,dll,dll.name,keyword,core,,kernel32.dll,Name of the library.
+1.11.0-dev,TRUE,dll,dll.path,keyword,extended,,C:\Windows\System32\kernel32.dll,Full file path of the library.
+1.11.0-dev,TRUE,dll,dll.pe.architecture,keyword,extended,,x64,CPU architecture target for the file.
+1.11.0-dev,TRUE,dll,dll.pe.company,keyword,extended,,Microsoft Corporation,"Internal company name of the file, provided at compile-time."
+1.11.0-dev,TRUE,dll,dll.pe.description,keyword,extended,,Paint,"Internal description of the file, provided at compile-time."
+1.11.0-dev,TRUE,dll,dll.pe.file_version,keyword,extended,,6.3.9600.17415,Process name.
+1.11.0-dev,TRUE,dll,dll.pe.imphash,keyword,extended,,0c6803c4e922103c4dca5963aad36ddf,A hash of the imports in a PE file.
+1.11.0-dev,TRUE,dll,dll.pe.original_file_name,keyword,extended,,MSPAINT.EXE,"Internal name of the file, provided at compile-time."
+1.11.0-dev,TRUE,dll,dll.pe.product,keyword,extended,,MicrosoftÂ® WindowsÂ® Operating System,"Internal product name of the file, provided at compile-time."
+1.11.0-dev,TRUE,dns,dns.answers,object,extended,array,,Array of DNS answers.
+1.11.0-dev,TRUE,dns,dns.answers.class,keyword,extended,,IN,The class of DNS data contained in this resource record.
+1.11.0-dev,TRUE,dns,dns.answers.data,keyword,extended,,10.10.10.10,The data describing the resource.
+1.11.0-dev,TRUE,dns,dns.answers.name,keyword,extended,,www.example.com,The domain name to which this resource record pertains.
+1.11.0-dev,TRUE,dns,dns.answers.ttl,long,extended,,180,The time interval in seconds that this resource record may be cached before it should be discarded.
+1.11.0-dev,TRUE,dns,dns.answers.type,keyword,extended,,CNAME,The type of data contained in this resource record.
+1.11.0-dev,TRUE,dns,dns.header_flags,keyword,extended,array,"[""RD"", ""RA""]",Array of DNS header flags.
+1.11.0-dev,TRUE,dns,dns.id,keyword,extended,,62111,The DNS packet identifier assigned by the program that generated the query. The identifier is copied to the response.
+1.11.0-dev,TRUE,dns,dns.op_code,keyword,extended,,QUERY,The DNS operation code that specifies the kind of query in the message.
+1.11.0-dev,TRUE,dns,dns.question.class,keyword,extended,,IN,The class of records being queried.
+1.11.0-dev,TRUE,dns,dns.question.name,keyword,extended,,www.example.com,The name being queried.
+1.11.0-dev,TRUE,dns,dns.question.registered_domain,keyword,extended,,example.com,"The highest registered domain, stripped of the subdomain."
+1.11.0-dev,TRUE,dns,dns.question.subdomain,keyword,extended,,www,The subdomain of the domain.
+1.11.0-dev,TRUE,dns,dns.question.top_level_domain,keyword,extended,,co.uk,"The effective top level domain (com, org, net, co.uk)."
+1.11.0-dev,TRUE,dns,dns.question.type,keyword,extended,,AAAA,The type of record being queried.
+1.11.0-dev,TRUE,dns,dns.resolved_ip,ip,extended,array,"[""10.10.10.10"", ""10.10.10.11""]",Array containing all IPs seen in answers.data
+1.11.0-dev,TRUE,dns,dns.response_code,keyword,extended,,NOERROR,The DNS response code.
+1.11.0-dev,TRUE,dns,dns.type,keyword,extended,,answer,"The type of DNS event captured, query or answer."
+1.11.0-dev,TRUE,ecs,ecs.version,keyword,core,,1.0.0,ECS version this event conforms to.
+1.11.0-dev,TRUE,error,error.code,keyword,core,,,Error code describing the error.
+1.11.0-dev,TRUE,error,error.id,keyword,core,,,Unique identifier for the error.
+1.11.0-dev,TRUE,error,error.message,text,core,,,Error message.
+1.11.0-dev,FALSE,error,error.stack_trace,keyword,extended,,,The stack trace of this error in plain text.
+1.11.0-dev,FALSE,error,error.stack_trace.text,text,extended,,,The stack trace of this error in plain text.
+1.11.0-dev,TRUE,error,error.type,keyword,extended,,java.lang.NullPointerException,"The type of the error, for example the class name of the exception."
+1.11.0-dev,TRUE,event,event.action,keyword,core,,user-password-change,The action captured by the event.
+1.11.0-dev,TRUE,event,event.agent_id_status,keyword,extended,,verified,Validation status of the event's agent.id field.
+1.11.0-dev,TRUE,event,event.category,keyword,core,array,authentication,Event category. The second categorization field in the hierarchy.
+1.11.0-dev,TRUE,event,event.code,keyword,extended,,4648,Identification code for this event.
+1.11.0-dev,TRUE,event,event.created,date,core,,2016-05-23T08:05:34.857Z,Time when the event was first read by an agent or by your pipeline.
+1.11.0-dev,TRUE,event,event.dataset,keyword,core,,apache.access,Name of the dataset.
+1.11.0-dev,TRUE,event,event.duration,long,core,,,Duration of the event in nanoseconds.
+1.11.0-dev,TRUE,event,event.end,date,extended,,,event.end contains the date when the event ended or when the activity was last observed.
+1.11.0-dev,TRUE,event,event.hash,keyword,extended,,123456789012345678901234567890ABCD,Hash (perhaps logstash fingerprint) of raw field to be able to demonstrate log integrity.
+1.11.0-dev,TRUE,event,event.id,keyword,core,,8a4f500d,Unique ID to describe the event.
+1.11.0-dev,TRUE,event,event.ingested,date,core,,2016-05-23T08:05:35.101Z,Timestamp when an event arrived in the central data store.
+1.11.0-dev,TRUE,event,event.kind,keyword,core,,alert,The kind of the event. The highest categorization field in the hierarchy.
+1.11.0-dev,TRUE,event,event.module,keyword,core,,apache,Name of the module this data is coming from.
+1.11.0-dev,FALSE,event,event.original,keyword,core,,Sep 19 08:26:10 host CEF:0&#124;Security&#124; threatmanager&#124;1.0&#124;100&#124; worm successfully stopped&#124;10&#124;src=10.0.0.1 dst=2.1.2.2spt=1232,Raw text message of entire event.
+1.11.0-dev,TRUE,event,event.outcome,keyword,core,,success,The outcome of the event. The lowest level categorization field in the hierarchy.
+1.11.0-dev,TRUE,event,event.provider,keyword,extended,,kernel,Source of the event.
+1.11.0-dev,TRUE,event,event.reason,keyword,extended,,Terminated an unexpected process,"Reason why this event happened, according to the source"
+1.11.0-dev,TRUE,event,event.reference,keyword,extended,,https://system.example.com/event/#0001234,Event reference URL
+1.11.0-dev,TRUE,event,event.risk_score,float,core,,,Risk score or priority of the event (e.g. security solutions). Use your system's original value here.
+1.11.0-dev,TRUE,event,event.risk_score_norm,float,extended,,,Normalized risk score or priority of the event (0-100).
+1.11.0-dev,TRUE,event,event.sequence,long,extended,,,Sequence number of the event.
+1.11.0-dev,TRUE,event,event.severity,long,core,,7,Numeric severity of the event.
+1.11.0-dev,TRUE,event,event.start,date,extended,,,event.start contains the date when the event started or when the activity was first observed.
+1.11.0-dev,TRUE,event,event.timezone,keyword,extended,,,Event time zone.
+1.11.0-dev,TRUE,event,event.type,keyword,core,array,,Event type. The third categorization field in the hierarchy.
+1.11.0-dev,TRUE,event,event.url,keyword,extended,,https://mysystem.example.com/alert/5271dedb-f5b0-4218-87f0-4ac4870a38fe,Event investigation URL
+1.11.0-dev,TRUE,file,file.accessed,date,extended,,,Last time the file was accessed.
+1.11.0-dev,TRUE,file,file.attributes,keyword,extended,array,"[""readonly"", ""system""]",Array of file attributes.
+1.11.0-dev,TRUE,file,file.code_signature.exists,boolean,core,,TRUE,Boolean to capture if a signature is present.
+1.11.0-dev,TRUE,file,file.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
+1.11.0-dev,TRUE,file,file.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
+1.11.0-dev,TRUE,file,file.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
+1.11.0-dev,TRUE,file,file.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
+1.11.0-dev,TRUE,file,file.code_signature.trusted,boolean,extended,,TRUE,Stores the trust status of the certificate chain.
+1.11.0-dev,TRUE,file,file.code_signature.valid,boolean,extended,,TRUE,Boolean to capture if the digital signature is verified against the binary content.
+1.11.0-dev,TRUE,file,file.created,date,extended,,,File creation time.
+1.11.0-dev,TRUE,file,file.ctime,date,extended,,,Last time the file attributes or metadata changed.
+1.11.0-dev,TRUE,file,file.device,keyword,extended,,sda,Device that is the source of the file.
+1.11.0-dev,TRUE,file,file.directory,keyword,extended,,/home/alice,Directory where the file is located.
+1.11.0-dev,TRUE,file,file.drive_letter,keyword,extended,,C,Drive letter where the file is located.
+1.11.0-dev,TRUE,file,file.elf.architecture,keyword,extended,,x86-64,Machine architecture of the ELF file.
+1.11.0-dev,TRUE,file,file.elf.byte_order,keyword,extended,,Little Endian,Byte sequence of ELF file.
+1.11.0-dev,TRUE,file,file.elf.cpu_type,keyword,extended,,Intel,CPU type of the ELF file.
+1.11.0-dev,TRUE,file,file.elf.creation_date,date,extended,,,Build or compile date.
+1.11.0-dev,TRUE,file,file.elf.exports,flattened,extended,array,,List of exported element names and types.
+1.11.0-dev,TRUE,file,file.elf.header.abi_version,keyword,extended,,,Version of the ELF Application Binary Interface (ABI).
+1.11.0-dev,TRUE,file,file.elf.header.class,keyword,extended,,,Header class of the ELF file.
+1.11.0-dev,TRUE,file,file.elf.header.data,keyword,extended,,,Data table of the ELF header.
+1.11.0-dev,TRUE,file,file.elf.header.entrypoint,long,extended,,,Header entrypoint of the ELF file.
+1.11.0-dev,TRUE,file,file.elf.header.object_version,keyword,extended,,,"""0x1"" for original ELF files."
+1.11.0-dev,TRUE,file,file.elf.header.os_abi,keyword,extended,,,Application Binary Interface (ABI) of the Linux OS.
+1.11.0-dev,TRUE,file,file.elf.header.type,keyword,extended,,,Header type of the ELF file.
+1.11.0-dev,TRUE,file,file.elf.header.version,keyword,extended,,,Version of the ELF header.
+1.11.0-dev,TRUE,file,file.elf.imports,flattened,extended,array,,List of imported element names and types.
+1.11.0-dev,TRUE,file,file.elf.sections,nested,extended,array,,Section information of the ELF file.
+1.11.0-dev,TRUE,file,file.elf.sections.chi2,long,extended,,,Chi-square probability distribution of the section.
+1.11.0-dev,TRUE,file,file.elf.sections.entropy,long,extended,,,Shannon entropy calculation from the section.
+1.11.0-dev,TRUE,file,file.elf.sections.flags,keyword,extended,,,ELF Section List flags.
+1.11.0-dev,TRUE,file,file.elf.sections.name,keyword,extended,,,ELF Section List name.
+1.11.0-dev,TRUE,file,file.elf.sections.physical_offset,keyword,extended,,,ELF Section List offset.
+1.11.0-dev,TRUE,file,file.elf.sections.physical_size,long,extended,,,ELF Section List physical size.
+1.11.0-dev,TRUE,file,file.elf.sections.type,keyword,extended,,,ELF Section List type.
+1.11.0-dev,TRUE,file,file.elf.sections.virtual_address,long,extended,,,ELF Section List virtual address.
+1.11.0-dev,TRUE,file,file.elf.sections.virtual_size,long,extended,,,ELF Section List virtual size.
+1.11.0-dev,TRUE,file,file.elf.segments,nested,extended,array,,ELF object segment list.
+1.11.0-dev,TRUE,file,file.elf.segments.sections,keyword,extended,,,ELF object segment sections.
+1.11.0-dev,TRUE,file,file.elf.segments.type,keyword,extended,,,ELF object segment type.
+1.11.0-dev,TRUE,file,file.elf.shared_libraries,keyword,extended,array,,List of shared libraries used by this ELF object.
+1.11.0-dev,TRUE,file,file.elf.telfhash,keyword,extended,,,telfhash hash for ELF file.
+1.11.0-dev,TRUE,file,file.extension,keyword,extended,,png,"File extension, excluding the leading dot."
+1.11.0-dev,TRUE,file,file.gid,keyword,extended,,1001,Primary group ID (GID) of the file.
+1.11.0-dev,TRUE,file,file.group,keyword,extended,,alice,Primary group name of the file.
+1.11.0-dev,TRUE,file,file.hash.md5,keyword,extended,,,MD5 hash.
+1.11.0-dev,TRUE,file,file.hash.sha1,keyword,extended,,,SHA1 hash.
+1.11.0-dev,TRUE,file,file.hash.sha256,keyword,extended,,,SHA256 hash.
+1.11.0-dev,TRUE,file,file.hash.sha512,keyword,extended,,,SHA512 hash.
+1.11.0-dev,TRUE,file,file.hash.ssdeep,keyword,extended,,,SSDEEP hash.
+1.11.0-dev,TRUE,file,file.inode,keyword,extended,,256383,Inode representing the file in the filesystem.
+1.11.0-dev,TRUE,file,file.mime_type,keyword,extended,,,"Media type of file, document, or arrangement of bytes."
+1.11.0-dev,TRUE,file,file.mode,keyword,extended,,640,Mode of the file in octal representation.
+1.11.0-dev,TRUE,file,file.mtime,date,extended,,,Last time the file content was modified.
+1.11.0-dev,TRUE,file,file.name,keyword,extended,,example.png,"Name of the file including the extension, without the directory."
+1.11.0-dev,TRUE,file,file.owner,keyword,extended,,alice,File owner's username.
+1.11.0-dev,TRUE,file,file.path,keyword,extended,,/home/alice/example.png,"Full path to the file, including the file name."
+1.11.0-dev,TRUE,file,file.path.text,text,extended,,/home/alice/example.png,"Full path to the file, including the file name."
+1.11.0-dev,TRUE,file,file.pe.architecture,keyword,extended,,x64,CPU architecture target for the file.
+1.11.0-dev,TRUE,file,file.pe.company,keyword,extended,,Microsoft Corporation,"Internal company name of the file, provided at compile-time."
+1.11.0-dev,TRUE,file,file.pe.description,keyword,extended,,Paint,"Internal description of the file, provided at compile-time."
+1.11.0-dev,TRUE,file,file.pe.file_version,keyword,extended,,6.3.9600.17415,Process name.
+1.11.0-dev,TRUE,file,file.pe.imphash,keyword,extended,,0c6803c4e922103c4dca5963aad36ddf,A hash of the imports in a PE file.
+1.11.0-dev,TRUE,file,file.pe.original_file_name,keyword,extended,,MSPAINT.EXE,"Internal name of the file, provided at compile-time."
+1.11.0-dev,TRUE,file,file.pe.product,keyword,extended,,MicrosoftÂ® WindowsÂ® Operating System,"Internal product name of the file, provided at compile-time."
+1.11.0-dev,TRUE,file,file.size,long,extended,,16384,File size in bytes.
+1.11.0-dev,TRUE,file,file.target_path,keyword,extended,,,Target path for symlinks.
+1.11.0-dev,TRUE,file,file.target_path.text,text,extended,,,Target path for symlinks.
+1.11.0-dev,TRUE,file,file.type,keyword,extended,,file,"File type (file, dir, or symlink)."
+1.11.0-dev,TRUE,file,file.uid,keyword,extended,,1001,The user ID (UID) or security identifier (SID) of the file owner.
+1.11.0-dev,TRUE,file,file.x509.alternative_names,keyword,extended,array,*.elastic.co,List of subject alternative names (SAN).
+1.11.0-dev,TRUE,file,file.x509.issuer.common_name,keyword,extended,array,Example SHA2 High Assurance Server CA,List of common name (CN) of issuing certificate authority.
+1.11.0-dev,TRUE,file,file.x509.issuer.country,keyword,extended,array,US,List of country (C) codes
+1.11.0-dev,TRUE,file,file.x509.issuer.distinguished_name,keyword,extended,,"C=US, O=Example Inc, OU=www.example.com, CN=Example SHA2 High Assurance Server CA",Distinguished name (DN) of issuing certificate authority.
+1.11.0-dev,TRUE,file,file.x509.issuer.locality,keyword,extended,array,Mountain View,List of locality names (L)
+1.11.0-dev,TRUE,file,file.x509.issuer.organization,keyword,extended,array,Example Inc,List of organizations (O) of issuing certificate authority.
+1.11.0-dev,TRUE,file,file.x509.issuer.organizational_unit,keyword,extended,array,www.example.com,List of organizational units (OU) of issuing certificate authority.
+1.11.0-dev,TRUE,file,file.x509.issuer.state_or_province,keyword,extended,array,California,"List of state or province names (ST, S, or P)"
+1.11.0-dev,TRUE,file,file.x509.not_after,date,extended,,2020-07-16 03:15:39+00:00,Time at which the certificate is no longer considered valid.
+1.11.0-dev,TRUE,file,file.x509.not_before,date,extended,,2019-08-16 01:40:25+00:00,Time at which the certificate is first considered valid.
+1.11.0-dev,TRUE,file,file.x509.public_key_algorithm,keyword,extended,,RSA,Algorithm used to generate the public key.
+1.11.0-dev,TRUE,file,file.x509.public_key_curve,keyword,extended,,nistp521,The curve used by the elliptic curve public key algorithm. This is algorithm specific.
+1.11.0-dev,FALSE,file,file.x509.public_key_exponent,long,extended,,65537,Exponent used to derive the public key. This is algorithm specific.
+1.11.0-dev,TRUE,file,file.x509.public_key_size,long,extended,,2048,The size of the public key space in bits.
+1.11.0-dev,TRUE,file,file.x509.serial_number,keyword,extended,,55FBB9C7DEBF09809D12CCAA,Unique serial number issued by the certificate authority.
+1.11.0-dev,TRUE,file,file.x509.signature_algorithm,keyword,extended,,SHA256-RSA,Identifier for certificate signature algorithm.
+1.11.0-dev,TRUE,file,file.x509.subject.common_name,keyword,extended,array,shared.global.example.net,List of common names (CN) of subject.
+1.11.0-dev,TRUE,file,file.x509.subject.country,keyword,extended,array,US,List of country (C) code
+1.11.0-dev,TRUE,file,file.x509.subject.distinguished_name,keyword,extended,,"C=US, ST=California, L=San Francisco, O=Example, Inc., CN=shared.global.example.net",Distinguished name (DN) of the certificate subject entity.
+1.11.0-dev,TRUE,file,file.x509.subject.locality,keyword,extended,array,San Francisco,List of locality names (L)
+1.11.0-dev,TRUE,file,file.x509.subject.organization,keyword,extended,array,"Example, Inc.",List of organizations (O) of subject.
+1.11.0-dev,TRUE,file,file.x509.subject.organizational_unit,keyword,extended,array,,List of organizational units (OU) of subject.
+1.11.0-dev,TRUE,file,file.x509.subject.state_or_province,keyword,extended,array,California,"List of state or province names (ST, S, or P)"
+1.11.0-dev,TRUE,file,file.x509.version_number,keyword,extended,,3,Version of x509 format.
+1.11.0-dev,TRUE,group,group.domain,keyword,extended,,,Name of the directory the group is a member of.
+1.11.0-dev,TRUE,group,group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
+1.11.0-dev,TRUE,group,group.name,keyword,extended,,,Name of the group.
+1.11.0-dev,TRUE,host,host.architecture,keyword,core,,x86_64,Operating system architecture.
+1.11.0-dev,TRUE,host,host.cpu.usage,scaled_float,extended,,,"Percent CPU used, between 0 and 1."
+1.11.0-dev,TRUE,host,host.disk.read.bytes,long,extended,,,The number of bytes read by all disks.
+1.11.0-dev,TRUE,host,host.disk.write.bytes,long,extended,,,The number of bytes written on all disks.
+1.11.0-dev,TRUE,host,host.domain,keyword,extended,,CONTOSO,Name of the directory the group is a member of.
+1.11.0-dev,TRUE,host,host.geo.city_name,keyword,core,,Montreal,City name.
+1.11.0-dev,TRUE,host,host.geo.continent_code,keyword,core,,NA,Continent code.
+1.11.0-dev,TRUE,host,host.geo.continent_name,keyword,core,,North America,Name of the continent.
+1.11.0-dev,TRUE,host,host.geo.country_iso_code,keyword,core,,CA,Country ISO code.
+1.11.0-dev,TRUE,host,host.geo.country_name,keyword,core,,Canada,Country name.
+1.11.0-dev,TRUE,host,host.geo.location,geo_point,core,,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
+1.11.0-dev,TRUE,host,host.geo.name,keyword,extended,,boston-dc,User-defined description of a location.
+1.11.0-dev,TRUE,host,host.geo.postal_code,keyword,core,,94040,Postal code.
+1.11.0-dev,TRUE,host,host.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
+1.11.0-dev,TRUE,host,host.geo.region_name,keyword,core,,Quebec,Region name.
+1.11.0-dev,TRUE,host,host.geo.timezone,keyword,core,,America/Argentina/Buenos_Aires,Time zone.
+1.11.0-dev,TRUE,host,host.hostname,keyword,core,,,Hostname of the host.
+1.11.0-dev,TRUE,host,host.id,keyword,core,,,Unique host id.
+1.11.0-dev,TRUE,host,host.ip,ip,core,array,,Host ip addresses.
+1.11.0-dev,TRUE,host,host.mac,keyword,core,array,"[""00-00-5E-00-53-23"", ""00-00-5E-00-53-24""]",Host MAC addresses.
+1.11.0-dev,TRUE,host,host.name,keyword,core,,,Name of the host.
+1.11.0-dev,TRUE,host,host.network.egress.bytes,long,extended,,,The number of bytes sent on all network interfaces.
+1.11.0-dev,TRUE,host,host.network.egress.packets,long,extended,,,The number of packets sent on all network interfaces.
+1.11.0-dev,TRUE,host,host.network.ingress.bytes,long,extended,,,The number of bytes received on all network interfaces.
+1.11.0-dev,TRUE,host,host.network.ingress.packets,long,extended,,,The number of packets received on all network interfaces.
+1.11.0-dev,TRUE,host,host.os.family,keyword,extended,,debian,"OS family (such as redhat, debian, freebsd, windows)."
+1.11.0-dev,TRUE,host,host.os.full,keyword,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
+1.11.0-dev,TRUE,host,host.os.full.text,text,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
+1.11.0-dev,TRUE,host,host.os.kernel,keyword,extended,,4.4.0-112-generic,Operating system kernel version as a raw string.
+1.11.0-dev,TRUE,host,host.os.name,keyword,extended,,Mac OS X,"Operating system name, without the version."
+1.11.0-dev,TRUE,host,host.os.name.text,text,extended,,Mac OS X,"Operating system name, without the version."
+1.11.0-dev,TRUE,host,host.os.platform,keyword,extended,,darwin,"Operating system platform (such centos, ubuntu, windows)."
+1.11.0-dev,TRUE,host,host.os.type,keyword,extended,,macos,"Which commercial OS family (one of: linux, macos, unix or windows)."
+1.11.0-dev,TRUE,host,host.os.version,keyword,extended,,10.14.1,Operating system version as a raw string.
+1.11.0-dev,TRUE,host,host.type,keyword,core,,,Type of host.
+1.11.0-dev,TRUE,host,host.uptime,long,extended,,1325,Seconds the host has been up.
+1.11.0-dev,TRUE,host,host.user.domain,keyword,extended,,,Name of the directory the user is a member of.
+1.11.0-dev,TRUE,host,host.user.email,keyword,extended,,,User email address.
+1.11.0-dev,TRUE,host,host.user.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
+1.11.0-dev,TRUE,host,host.user.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
+1.11.0-dev,TRUE,host,host.user.group.domain,keyword,extended,,,Name of the directory the group is a member of.
+1.11.0-dev,TRUE,host,host.user.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
+1.11.0-dev,TRUE,host,host.user.group.name,keyword,extended,,,Name of the group.
+1.11.0-dev,TRUE,host,host.user.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
+1.11.0-dev,TRUE,host,host.user.id,keyword,core,,,Unique identifier of the user.
+1.11.0-dev,TRUE,host,host.user.name,keyword,core,,albert,Short name or login of the user.
+1.11.0-dev,TRUE,host,host.user.name.text,text,core,,albert,Short name or login of the user.
+1.11.0-dev,TRUE,host,host.user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
+1.11.0-dev,TRUE,http,http.request.body.bytes,long,extended,,887,Size in bytes of the request body.
+1.11.0-dev,TRUE,http,http.request.body.content,keyword,extended,,Hello world,The full HTTP request body.
+1.11.0-dev,TRUE,http,http.request.body.content.text,text,extended,,Hello world,The full HTTP request body.
+1.11.0-dev,TRUE,http,http.request.bytes,long,extended,,1437,Total size in bytes of the request (body and headers).
+1.11.0-dev,TRUE,http,http.request.id,keyword,extended,,123e4567-e89b-12d3-a456-426614174000,HTTP request ID.
+1.11.0-dev,TRUE,http,http.request.method,keyword,extended,,"GET, POST, PUT, PoST",HTTP request method.
+1.11.0-dev,TRUE,http,http.request.mime_type,keyword,extended,,image/gif,Mime type of the body of the request.
+1.11.0-dev,TRUE,http,http.request.referrer,keyword,extended,,https://blog.example.com/,Referrer for this HTTP request.
+1.11.0-dev,TRUE,http,http.response.body.bytes,long,extended,,887,Size in bytes of the response body.
+1.11.0-dev,TRUE,http,http.response.body.content,keyword,extended,,Hello world,The full HTTP response body.
+1.11.0-dev,TRUE,http,http.response.body.content.text,text,extended,,Hello world,The full HTTP response body.
+1.11.0-dev,TRUE,http,http.response.bytes,long,extended,,1437,Total size in bytes of the response (body and headers).
+1.11.0-dev,TRUE,http,http.response.mime_type,keyword,extended,,image/gif,Mime type of the body of the response.
+1.11.0-dev,TRUE,http,http.response.status_code,long,extended,,404,HTTP response status code.
+1.11.0-dev,TRUE,http,http.version,keyword,extended,,1.1,HTTP version.
+1.11.0-dev,TRUE,log,log.file.path,keyword,extended,,/var/log/fun-times.log,Full path to the log file this event came from.
+1.11.0-dev,TRUE,log,log.level,keyword,core,,error,Log level of the log event.
+1.11.0-dev,TRUE,log,log.logger,keyword,core,,org.elasticsearch.bootstrap.Bootstrap,Name of the logger.
+1.11.0-dev,TRUE,log,log.origin.file.line,integer,extended,,42,The line number of the file which originated the log event.
+1.11.0-dev,TRUE,log,log.origin.file.name,keyword,extended,,Bootstrap.java,The code file which originated the log event.
+1.11.0-dev,TRUE,log,log.origin.function,keyword,extended,,init,The function which originated the log event.
+1.11.0-dev,FALSE,log,log.original,keyword,core,,Sep 19 08:26:10 localhost My log,"Deprecated original log message with light interpretation only (encoding, newlines)."
+1.11.0-dev,TRUE,log,log.syslog,object,extended,,,Syslog metadata
+1.11.0-dev,TRUE,log,log.syslog.facility.code,long,extended,,23,Syslog numeric facility of the event.
+1.11.0-dev,TRUE,log,log.syslog.facility.name,keyword,extended,,local7,Syslog text-based facility of the event.
+1.11.0-dev,TRUE,log,log.syslog.priority,long,extended,,135,Syslog priority of the event.
+1.11.0-dev,TRUE,log,log.syslog.severity.code,long,extended,,3,Syslog numeric severity of the event.
+1.11.0-dev,TRUE,log,log.syslog.severity.name,keyword,extended,,Error,Syslog text-based severity of the event.
+1.11.0-dev,TRUE,network,network.application,keyword,extended,,aim,Application level protocol name.
+1.11.0-dev,TRUE,network,network.bytes,long,core,,368,Total bytes transferred in both directions.
+1.11.0-dev,TRUE,network,network.community_id,keyword,extended,,1:hO+sN4H+MG5MY/8hIrXPqc4ZQz0=,A hash of source and destination IPs and ports.
+1.11.0-dev,TRUE,network,network.direction,keyword,core,,inbound,Direction of the network traffic.
+1.11.0-dev,TRUE,network,network.forwarded_ip,ip,core,,192.1.1.2,Host IP address when the source IP address is the proxy.
+1.11.0-dev,TRUE,network,network.iana_number,keyword,extended,,6,IANA Protocol Number.
+1.11.0-dev,TRUE,network,network.inner,object,extended,,,Inner VLAN tag information
+1.11.0-dev,TRUE,network,network.inner.vlan.id,keyword,extended,,10,VLAN ID as reported by the observer.
+1.11.0-dev,TRUE,network,network.inner.vlan.name,keyword,extended,,outside,Optional VLAN name as reported by the observer.
+1.11.0-dev,TRUE,network,network.name,keyword,extended,,Guest Wifi,Name given by operators to sections of their network.
+1.11.0-dev,TRUE,network,network.packets,long,core,,24,Total packets transferred in both directions.
+1.11.0-dev,TRUE,network,network.protocol,keyword,core,,http,L7 Network protocol name.
+1.11.0-dev,TRUE,network,network.transport,keyword,core,,tcp,Protocol Name corresponding to the field `iana_number`.
+1.11.0-dev,TRUE,network,network.type,keyword,core,,ipv4,"In the OSI Model this would be the Network Layer. ipv4, ipv6, ipsec, pim, etc"
+1.11.0-dev,TRUE,network,network.vlan.id,keyword,extended,,10,VLAN ID as reported by the observer.
+1.11.0-dev,TRUE,network,network.vlan.name,keyword,extended,,outside,Optional VLAN name as reported by the observer.
+1.11.0-dev,TRUE,observer,observer.egress,object,extended,,,Object field for egress information
+1.11.0-dev,TRUE,observer,observer.egress.interface.alias,keyword,extended,,outside,Interface alias
+1.11.0-dev,TRUE,observer,observer.egress.interface.id,keyword,extended,,10,Interface ID
+1.11.0-dev,TRUE,observer,observer.egress.interface.name,keyword,extended,,eth0,Interface name
+1.11.0-dev,TRUE,observer,observer.egress.vlan.id,keyword,extended,,10,VLAN ID as reported by the observer.
+1.11.0-dev,TRUE,observer,observer.egress.vlan.name,keyword,extended,,outside,Optional VLAN name as reported by the observer.
+1.11.0-dev,TRUE,observer,observer.egress.zone,keyword,extended,,Public_Internet,Observer Egress zone
+1.11.0-dev,TRUE,observer,observer.geo.city_name,keyword,core,,Montreal,City name.
+1.11.0-dev,TRUE,observer,observer.geo.continent_code,keyword,core,,NA,Continent code.
+1.11.0-dev,TRUE,observer,observer.geo.continent_name,keyword,core,,North America,Name of the continent.
+1.11.0-dev,TRUE,observer,observer.geo.country_iso_code,keyword,core,,CA,Country ISO code.
+1.11.0-dev,TRUE,observer,observer.geo.country_name,keyword,core,,Canada,Country name.
+1.11.0-dev,TRUE,observer,observer.geo.location,geo_point,core,,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
+1.11.0-dev,TRUE,observer,observer.geo.name,keyword,extended,,boston-dc,User-defined description of a location.
+1.11.0-dev,TRUE,observer,observer.geo.postal_code,keyword,core,,94040,Postal code.
+1.11.0-dev,TRUE,observer,observer.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
+1.11.0-dev,TRUE,observer,observer.geo.region_name,keyword,core,,Quebec,Region name.
+1.11.0-dev,TRUE,observer,observer.geo.timezone,keyword,core,,America/Argentina/Buenos_Aires,Time zone.
+1.11.0-dev,TRUE,observer,observer.hostname,keyword,core,,,Hostname of the observer.
+1.11.0-dev,TRUE,observer,observer.ingress,object,extended,,,Object field for ingress information
+1.11.0-dev,TRUE,observer,observer.ingress.interface.alias,keyword,extended,,outside,Interface alias
+1.11.0-dev,TRUE,observer,observer.ingress.interface.id,keyword,extended,,10,Interface ID
+1.11.0-dev,TRUE,observer,observer.ingress.interface.name,keyword,extended,,eth0,Interface name
+1.11.0-dev,TRUE,observer,observer.ingress.vlan.id,keyword,extended,,10,VLAN ID as reported by the observer.
+1.11.0-dev,TRUE,observer,observer.ingress.vlan.name,keyword,extended,,outside,Optional VLAN name as reported by the observer.
+1.11.0-dev,TRUE,observer,observer.ingress.zone,keyword,extended,,DMZ,Observer ingress zone
+1.11.0-dev,TRUE,observer,observer.ip,ip,core,array,,IP addresses of the observer.
+1.11.0-dev,TRUE,observer,observer.mac,keyword,core,array,"[""00-00-5E-00-53-23"", ""00-00-5E-00-53-24""]",MAC addresses of the observer.
+1.11.0-dev,TRUE,observer,observer.name,keyword,extended,,1_proxySG,Custom name of the observer.
+1.11.0-dev,TRUE,observer,observer.os.family,keyword,extended,,debian,"OS family (such as redhat, debian, freebsd, windows)."
+1.11.0-dev,TRUE,observer,observer.os.full,keyword,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
+1.11.0-dev,TRUE,observer,observer.os.full.text,text,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
+1.11.0-dev,TRUE,observer,observer.os.kernel,keyword,extended,,4.4.0-112-generic,Operating system kernel version as a raw string.
+1.11.0-dev,TRUE,observer,observer.os.name,keyword,extended,,Mac OS X,"Operating system name, without the version."
+1.11.0-dev,TRUE,observer,observer.os.name.text,text,extended,,Mac OS X,"Operating system name, without the version."
+1.11.0-dev,TRUE,observer,observer.os.platform,keyword,extended,,darwin,"Operating system platform (such centos, ubuntu, windows)."
+1.11.0-dev,TRUE,observer,observer.os.type,keyword,extended,,macos,"Which commercial OS family (one of: linux, macos, unix or windows)."
+1.11.0-dev,TRUE,observer,observer.os.version,keyword,extended,,10.14.1,Operating system version as a raw string.
+1.11.0-dev,TRUE,observer,observer.product,keyword,extended,,s200,The product name of the observer.
+1.11.0-dev,TRUE,observer,observer.serial_number,keyword,extended,,,Observer serial number.
+1.11.0-dev,TRUE,observer,observer.type,keyword,core,,firewall,The type of the observer the data is coming from.
+1.11.0-dev,TRUE,observer,observer.vendor,keyword,core,,Symantec,Vendor name of the observer.
+1.11.0-dev,TRUE,observer,observer.version,keyword,core,,,Observer version.
+1.11.0-dev,TRUE,orchestrator,orchestrator.api_version,keyword,extended,,v1beta1,API version being used to carry out the action
+1.11.0-dev,TRUE,orchestrator,orchestrator.cluster.name,keyword,extended,,,Name of the cluster.
+1.11.0-dev,TRUE,orchestrator,orchestrator.cluster.url,keyword,extended,,,URL of the API used to manage the cluster.
+1.11.0-dev,TRUE,orchestrator,orchestrator.cluster.version,keyword,extended,,,The version of the cluster.
+1.11.0-dev,TRUE,orchestrator,orchestrator.namespace,keyword,extended,,kube-system,Namespace in which the action is taking place.
+1.11.0-dev,TRUE,orchestrator,orchestrator.organization,keyword,extended,,elastic,Organization affected by the event (for multi-tenant orchestrator setups).
+1.11.0-dev,TRUE,orchestrator,orchestrator.resource.name,keyword,extended,,test-pod-cdcws,Name of the resource being acted upon.
+1.11.0-dev,TRUE,orchestrator,orchestrator.resource.type,keyword,extended,,service,Type of resource being acted upon.
+1.11.0-dev,TRUE,orchestrator,orchestrator.type,keyword,extended,,kubernetes,"Orchestrator cluster type (e.g. kubernetes, nomad or cloudfoundry)."
+1.11.0-dev,TRUE,organization,organization.id,keyword,extended,,,Unique identifier for the organization.
+1.11.0-dev,TRUE,organization,organization.name,keyword,extended,,,Organization name.
+1.11.0-dev,TRUE,organization,organization.name.text,text,extended,,,Organization name.
+1.11.0-dev,TRUE,package,package.architecture,keyword,extended,,x86_64,Package architecture.
+1.11.0-dev,TRUE,package,package.build_version,keyword,extended,,36f4f7e89dd61b0988b12ee000b98966867710cd,Build version information
+1.11.0-dev,TRUE,package,package.checksum,keyword,extended,,68b329da9893e34099c7d8ad5cb9c940,Checksum of the installed package for verification.
+1.11.0-dev,TRUE,package,package.description,keyword,extended,,Open source programming language to build simple/reliable/efficient software.,Description of the package.
+1.11.0-dev,TRUE,package,package.install_scope,keyword,extended,,global,"Indicating how the package was installed, e.g. user-local, global."
+1.11.0-dev,TRUE,package,package.installed,date,extended,,,Time when package was installed.
+1.11.0-dev,TRUE,package,package.license,keyword,extended,,Apache License 2.0,Package license
+1.11.0-dev,TRUE,package,package.name,keyword,extended,,go,Package name
+1.11.0-dev,TRUE,package,package.path,keyword,extended,,/usr/local/Cellar/go/1.12.9/,Path where the package is installed.
+1.11.0-dev,TRUE,package,package.reference,keyword,extended,,https://golang.org,Package home page or reference URL
+1.11.0-dev,TRUE,package,package.size,long,extended,,62231,Package size in bytes.
+1.11.0-dev,TRUE,package,package.type,keyword,extended,,rpm,Package type
+1.11.0-dev,TRUE,package,package.version,keyword,extended,,1.12.9,Package version
+1.11.0-dev,TRUE,process,process.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
+1.11.0-dev,TRUE,process,process.args_count,long,extended,,4,Length of the process.args array.
+1.11.0-dev,TRUE,process,process.code_signature.exists,boolean,core,,TRUE,Boolean to capture if a signature is present.
+1.11.0-dev,TRUE,process,process.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
+1.11.0-dev,TRUE,process,process.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
+1.11.0-dev,TRUE,process,process.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
+1.11.0-dev,TRUE,process,process.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
+1.11.0-dev,TRUE,process,process.code_signature.trusted,boolean,extended,,TRUE,Stores the trust status of the certificate chain.
+1.11.0-dev,TRUE,process,process.code_signature.valid,boolean,extended,,TRUE,Boolean to capture if the digital signature is verified against the binary content.
+1.11.0-dev,TRUE,process,process.command_line,keyword,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+1.11.0-dev,TRUE,process,process.command_line.text,text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+1.11.0-dev,TRUE,process,process.elf.architecture,keyword,extended,,x86-64,Machine architecture of the ELF file.
+1.11.0-dev,TRUE,process,process.elf.byte_order,keyword,extended,,Little Endian,Byte sequence of ELF file.
+1.11.0-dev,TRUE,process,process.elf.cpu_type,keyword,extended,,Intel,CPU type of the ELF file.
+1.11.0-dev,TRUE,process,process.elf.creation_date,date,extended,,,Build or compile date.
+1.11.0-dev,TRUE,process,process.elf.exports,flattened,extended,array,,List of exported element names and types.
+1.11.0-dev,TRUE,process,process.elf.header.abi_version,keyword,extended,,,Version of the ELF Application Binary Interface (ABI).
+1.11.0-dev,TRUE,process,process.elf.header.class,keyword,extended,,,Header class of the ELF file.
+1.11.0-dev,TRUE,process,process.elf.header.data,keyword,extended,,,Data table of the ELF header.
+1.11.0-dev,TRUE,process,process.elf.header.entrypoint,long,extended,,,Header entrypoint of the ELF file.
+1.11.0-dev,TRUE,process,process.elf.header.object_version,keyword,extended,,,"""0x1"" for original ELF files."
+1.11.0-dev,TRUE,process,process.elf.header.os_abi,keyword,extended,,,Application Binary Interface (ABI) of the Linux OS.
+1.11.0-dev,TRUE,process,process.elf.header.type,keyword,extended,,,Header type of the ELF file.
+1.11.0-dev,TRUE,process,process.elf.header.version,keyword,extended,,,Version of the ELF header.
+1.11.0-dev,TRUE,process,process.elf.imports,flattened,extended,array,,List of imported element names and types.
+1.11.0-dev,TRUE,process,process.elf.sections,nested,extended,array,,Section information of the ELF file.
+1.11.0-dev,TRUE,process,process.elf.sections.chi2,long,extended,,,Chi-square probability distribution of the section.
+1.11.0-dev,TRUE,process,process.elf.sections.entropy,long,extended,,,Shannon entropy calculation from the section.
+1.11.0-dev,TRUE,process,process.elf.sections.flags,keyword,extended,,,ELF Section List flags.
+1.11.0-dev,TRUE,process,process.elf.sections.name,keyword,extended,,,ELF Section List name.
+1.11.0-dev,TRUE,process,process.elf.sections.physical_offset,keyword,extended,,,ELF Section List offset.
+1.11.0-dev,TRUE,process,process.elf.sections.physical_size,long,extended,,,ELF Section List physical size.
+1.11.0-dev,TRUE,process,process.elf.sections.type,keyword,extended,,,ELF Section List type.
+1.11.0-dev,TRUE,process,process.elf.sections.virtual_address,long,extended,,,ELF Section List virtual address.
+1.11.0-dev,TRUE,process,process.elf.sections.virtual_size,long,extended,,,ELF Section List virtual size.
+1.11.0-dev,TRUE,process,process.elf.segments,nested,extended,array,,ELF object segment list.
+1.11.0-dev,TRUE,process,process.elf.segments.sections,keyword,extended,,,ELF object segment sections.
+1.11.0-dev,TRUE,process,process.elf.segments.type,keyword,extended,,,ELF object segment type.
+1.11.0-dev,TRUE,process,process.elf.shared_libraries,keyword,extended,array,,List of shared libraries used by this ELF object.
+1.11.0-dev,TRUE,process,process.elf.telfhash,keyword,extended,,,telfhash hash for ELF file.
+1.11.0-dev,TRUE,process,process.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
+1.11.0-dev,TRUE,process,process.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
+1.11.0-dev,TRUE,process,process.executable.text,text,extended,,/usr/bin/ssh,Absolute path to the process executable.
+1.11.0-dev,TRUE,process,process.exit_code,long,extended,,137,The exit code of the process.
+1.11.0-dev,TRUE,process,process.hash.md5,keyword,extended,,,MD5 hash.
+1.11.0-dev,TRUE,process,process.hash.sha1,keyword,extended,,,SHA1 hash.
+1.11.0-dev,TRUE,process,process.hash.sha256,keyword,extended,,,SHA256 hash.
+1.11.0-dev,TRUE,process,process.hash.sha512,keyword,extended,,,SHA512 hash.
+1.11.0-dev,TRUE,process,process.hash.ssdeep,keyword,extended,,,SSDEEP hash.
+1.11.0-dev,TRUE,process,process.name,keyword,extended,,ssh,Process name.
+1.11.0-dev,TRUE,process,process.name.text,text,extended,,ssh,Process name.
+1.11.0-dev,TRUE,process,process.parent.args,keyword,extended,array,"[""/usr/bin/ssh"", ""-l"", ""user"", ""10.0.0.16""]",Array of process arguments.
+1.11.0-dev,TRUE,process,process.parent.args_count,long,extended,,4,Length of the process.args array.
+1.11.0-dev,TRUE,process,process.parent.code_signature.exists,boolean,core,,TRUE,Boolean to capture if a signature is present.
+1.11.0-dev,TRUE,process,process.parent.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
+1.11.0-dev,TRUE,process,process.parent.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
+1.11.0-dev,TRUE,process,process.parent.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
+1.11.0-dev,TRUE,process,process.parent.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
+1.11.0-dev,TRUE,process,process.parent.code_signature.trusted,boolean,extended,,TRUE,Stores the trust status of the certificate chain.
+1.11.0-dev,TRUE,process,process.parent.code_signature.valid,boolean,extended,,TRUE,Boolean to capture if the digital signature is verified against the binary content.
+1.11.0-dev,TRUE,process,process.parent.command_line,keyword,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+1.11.0-dev,TRUE,process,process.parent.command_line.text,text,extended,,/usr/bin/ssh -l user 10.0.0.16,Full command line that started the process.
+1.11.0-dev,TRUE,process,process.parent.elf.architecture,keyword,extended,,x86-64,Machine architecture of the ELF file.
+1.11.0-dev,TRUE,process,process.parent.elf.byte_order,keyword,extended,,Little Endian,Byte sequence of ELF file.
+1.11.0-dev,TRUE,process,process.parent.elf.cpu_type,keyword,extended,,Intel,CPU type of the ELF file.
+1.11.0-dev,TRUE,process,process.parent.elf.creation_date,date,extended,,,Build or compile date.
+1.11.0-dev,TRUE,process,process.parent.elf.exports,flattened,extended,array,,List of exported element names and types.
+1.11.0-dev,TRUE,process,process.parent.elf.header.abi_version,keyword,extended,,,Version of the ELF Application Binary Interface (ABI).
+1.11.0-dev,TRUE,process,process.parent.elf.header.class,keyword,extended,,,Header class of the ELF file.
+1.11.0-dev,TRUE,process,process.parent.elf.header.data,keyword,extended,,,Data table of the ELF header.
+1.11.0-dev,TRUE,process,process.parent.elf.header.entrypoint,long,extended,,,Header entrypoint of the ELF file.
+1.11.0-dev,TRUE,process,process.parent.elf.header.object_version,keyword,extended,,,"""0x1"" for original ELF files."
+1.11.0-dev,TRUE,process,process.parent.elf.header.os_abi,keyword,extended,,,Application Binary Interface (ABI) of the Linux OS.
+1.11.0-dev,TRUE,process,process.parent.elf.header.type,keyword,extended,,,Header type of the ELF file.
+1.11.0-dev,TRUE,process,process.parent.elf.header.version,keyword,extended,,,Version of the ELF header.
+1.11.0-dev,TRUE,process,process.parent.elf.imports,flattened,extended,array,,List of imported element names and types.
+1.11.0-dev,TRUE,process,process.parent.elf.sections,nested,extended,array,,Section information of the ELF file.
+1.11.0-dev,TRUE,process,process.parent.elf.sections.chi2,long,extended,,,Chi-square probability distribution of the section.
+1.11.0-dev,TRUE,process,process.parent.elf.sections.entropy,long,extended,,,Shannon entropy calculation from the section.
+1.11.0-dev,TRUE,process,process.parent.elf.sections.flags,keyword,extended,,,ELF Section List flags.
+1.11.0-dev,TRUE,process,process.parent.elf.sections.name,keyword,extended,,,ELF Section List name.
+1.11.0-dev,TRUE,process,process.parent.elf.sections.physical_offset,keyword,extended,,,ELF Section List offset.
+1.11.0-dev,TRUE,process,process.parent.elf.sections.physical_size,long,extended,,,ELF Section List physical size.
+1.11.0-dev,TRUE,process,process.parent.elf.sections.type,keyword,extended,,,ELF Section List type.
+1.11.0-dev,TRUE,process,process.parent.elf.sections.virtual_address,long,extended,,,ELF Section List virtual address.
+1.11.0-dev,TRUE,process,process.parent.elf.sections.virtual_size,long,extended,,,ELF Section List virtual size.
+1.11.0-dev,TRUE,process,process.parent.elf.segments,nested,extended,array,,ELF object segment list.
+1.11.0-dev,TRUE,process,process.parent.elf.segments.sections,keyword,extended,,,ELF object segment sections.
+1.11.0-dev,TRUE,process,process.parent.elf.segments.type,keyword,extended,,,ELF object segment type.
+1.11.0-dev,TRUE,process,process.parent.elf.shared_libraries,keyword,extended,array,,List of shared libraries used by this ELF object.
+1.11.0-dev,TRUE,process,process.parent.elf.telfhash,keyword,extended,,,telfhash hash for ELF file.
+1.11.0-dev,TRUE,process,process.parent.entity_id,keyword,extended,,c2c455d9f99375d,Unique identifier for the process.
+1.11.0-dev,TRUE,process,process.parent.executable,keyword,extended,,/usr/bin/ssh,Absolute path to the process executable.
+1.11.0-dev,TRUE,process,process.parent.executable.text,text,extended,,/usr/bin/ssh,Absolute path to the process executable.
+1.11.0-dev,TRUE,process,process.parent.exit_code,long,extended,,137,The exit code of the process.
+1.11.0-dev,TRUE,process,process.parent.hash.md5,keyword,extended,,,MD5 hash.
+1.11.0-dev,TRUE,process,process.parent.hash.sha1,keyword,extended,,,SHA1 hash.
+1.11.0-dev,TRUE,process,process.parent.hash.sha256,keyword,extended,,,SHA256 hash.
+1.11.0-dev,TRUE,process,process.parent.hash.sha512,keyword,extended,,,SHA512 hash.
+1.11.0-dev,TRUE,process,process.parent.hash.ssdeep,keyword,extended,,,SSDEEP hash.
+1.11.0-dev,TRUE,process,process.parent.name,keyword,extended,,ssh,Process name.
+1.11.0-dev,TRUE,process,process.parent.name.text,text,extended,,ssh,Process name.
+1.11.0-dev,TRUE,process,process.parent.pe.architecture,keyword,extended,,x64,CPU architecture target for the file.
+1.11.0-dev,TRUE,process,process.parent.pe.company,keyword,extended,,Microsoft Corporation,"Internal company name of the file, provided at compile-time."
+1.11.0-dev,TRUE,process,process.parent.pe.description,keyword,extended,,Paint,"Internal description of the file, provided at compile-time."
+1.11.0-dev,TRUE,process,process.parent.pe.file_version,keyword,extended,,6.3.9600.17415,Process name.
+1.11.0-dev,TRUE,process,process.parent.pe.imphash,keyword,extended,,0c6803c4e922103c4dca5963aad36ddf,A hash of the imports in a PE file.
+1.11.0-dev,TRUE,process,process.parent.pe.original_file_name,keyword,extended,,MSPAINT.EXE,"Internal name of the file, provided at compile-time."
+1.11.0-dev,TRUE,process,process.parent.pe.product,keyword,extended,,MicrosoftÂ® WindowsÂ® Operating System,"Internal product name of the file, provided at compile-time."
+1.11.0-dev,TRUE,process,process.parent.pgid,long,extended,,,Identifier of the group of processes the process belongs to.
+1.11.0-dev,TRUE,process,process.parent.pid,long,core,,4242,Process id.
+1.11.0-dev,TRUE,process,process.parent.ppid,long,extended,,4241,Parent process' pid.
+1.11.0-dev,TRUE,process,process.parent.start,date,extended,,2016-05-23T08:05:34.853Z,The time the process started.
+1.11.0-dev,TRUE,process,process.parent.thread.id,long,extended,,4242,Thread ID.
+1.11.0-dev,TRUE,process,process.parent.thread.name,keyword,extended,,thread-0,Thread name.
+1.11.0-dev,TRUE,process,process.parent.title,keyword,extended,,,Process title.
+1.11.0-dev,TRUE,process,process.parent.title.text,text,extended,,,Process title.
+1.11.0-dev,TRUE,process,process.parent.uptime,long,extended,,1325,Seconds the process has been up.
+1.11.0-dev,TRUE,process,process.parent.working_directory,keyword,extended,,/home/alice,The working directory of the process.
+1.11.0-dev,TRUE,process,process.parent.working_directory.text,text,extended,,/home/alice,The working directory of the process.
+1.11.0-dev,TRUE,process,process.pe.architecture,keyword,extended,,x64,CPU architecture target for the file.
+1.11.0-dev,TRUE,process,process.pe.company,keyword,extended,,Microsoft Corporation,"Internal company name of the file, provided at compile-time."
+1.11.0-dev,TRUE,process,process.pe.description,keyword,extended,,Paint,"Internal description of the file, provided at compile-time."
+1.11.0-dev,TRUE,process,process.pe.file_version,keyword,extended,,6.3.9600.17415,Process name.
+1.11.0-dev,TRUE,process,process.pe.imphash,keyword,extended,,0c6803c4e922103c4dca5963aad36ddf,A hash of the imports in a PE file.
+1.11.0-dev,TRUE,process,process.pe.original_file_name,keyword,extended,,MSPAINT.EXE,"Internal name of the file, provided at compile-time."
+1.11.0-dev,TRUE,process,process.pe.product,keyword,extended,,MicrosoftÂ® WindowsÂ® Operating System,"Internal product name of the file, provided at compile-time."
+1.11.0-dev,TRUE,process,process.pgid,long,extended,,,Identifier of the group of processes the process belongs to.
+1.11.0-dev,TRUE,process,process.pid,long,core,,4242,Process id.
+1.11.0-dev,TRUE,process,process.ppid,long,extended,,4241,Parent process' pid.
+1.11.0-dev,TRUE,process,process.start,date,extended,,2016-05-23T08:05:34.853Z,The time the process started.
+1.11.0-dev,TRUE,process,process.thread.id,long,extended,,4242,Thread ID.
+1.11.0-dev,TRUE,process,process.thread.name,keyword,extended,,thread-0,Thread name.
+1.11.0-dev,TRUE,process,process.title,keyword,extended,,,Process title.
+1.11.0-dev,TRUE,process,process.title.text,text,extended,,,Process title.
+1.11.0-dev,TRUE,process,process.uptime,long,extended,,1325,Seconds the process has been up.
+1.11.0-dev,TRUE,process,process.working_directory,keyword,extended,,/home/alice,The working directory of the process.
+1.11.0-dev,TRUE,process,process.working_directory.text,text,extended,,/home/alice,The working directory of the process.
+1.11.0-dev,TRUE,registry,registry.data.bytes,keyword,extended,,ZQBuAC0AVQBTAAAAZQBuAAAAAAA=,Original bytes written with base64 encoding.
+1.11.0-dev,TRUE,registry,registry.data.strings,keyword,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
+1.11.0-dev,TRUE,registry,registry.data.type,keyword,core,,REG_SZ,Standard registry type for encoding contents
+1.11.0-dev,TRUE,registry,registry.hive,keyword,core,,HKLM,Abbreviated name for the hive.
+1.11.0-dev,TRUE,registry,registry.key,keyword,core,,SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\winword.exe,Hive-relative path of keys.
+1.11.0-dev,TRUE,registry,registry.path,keyword,core,,HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\winword.exe\Debugger,"Full path, including hive, key and value"
+1.11.0-dev,TRUE,registry,registry.value,keyword,core,,Debugger,Name of the value written.
+1.11.0-dev,TRUE,related,related.hash,keyword,extended,array,,All the hashes seen on your event.
+1.11.0-dev,TRUE,related,related.hosts,keyword,extended,array,,All the host identifiers seen on your event.
+1.11.0-dev,TRUE,related,related.ip,ip,extended,array,,All of the IPs seen on your event.
+1.11.0-dev,TRUE,related,related.user,keyword,extended,array,,All the user names or other user identifiers seen on the event.
+1.11.0-dev,TRUE,rule,rule.author,keyword,extended,array,"[""Star-Lord""]",Rule author
+1.11.0-dev,TRUE,rule,rule.category,keyword,extended,,Attempted Information Leak,Rule category
+1.11.0-dev,TRUE,rule,rule.description,keyword,extended,,Block requests to public DNS over HTTPS / TLS protocols,Rule description
+1.11.0-dev,TRUE,rule,rule.id,keyword,extended,,101,Rule ID
+1.11.0-dev,TRUE,rule,rule.license,keyword,extended,,Apache 2.0,Rule license
+1.11.0-dev,TRUE,rule,rule.name,keyword,extended,,BLOCK_DNS_over_TLS,Rule name
+1.11.0-dev,TRUE,rule,rule.reference,keyword,extended,,https://en.wikipedia.org/wiki/DNS_over_TLS,Rule reference URL
+1.11.0-dev,TRUE,rule,rule.ruleset,keyword,extended,,Standard_Protocol_Filters,Rule ruleset
+1.11.0-dev,TRUE,rule,rule.uuid,keyword,extended,,1100110011,Rule UUID
+1.11.0-dev,TRUE,rule,rule.version,keyword,extended,,1.1,Rule version
+1.11.0-dev,TRUE,server,server.address,keyword,extended,,,Server network address.
+1.11.0-dev,TRUE,server,server.as.number,long,extended,,15169,Unique number allocated to the autonomous system.
+1.11.0-dev,TRUE,server,server.as.organization.name,keyword,extended,,Google LLC,Organization name.
+1.11.0-dev,TRUE,server,server.as.organization.name.text,text,extended,,Google LLC,Organization name.
+1.11.0-dev,TRUE,server,server.bytes,long,core,,184,Bytes sent from the server to the client.
+1.11.0-dev,TRUE,server,server.domain,keyword,core,,,Server domain.
+1.11.0-dev,TRUE,server,server.geo.city_name,keyword,core,,Montreal,City name.
+1.11.0-dev,TRUE,server,server.geo.continent_code,keyword,core,,NA,Continent code.
+1.11.0-dev,TRUE,server,server.geo.continent_name,keyword,core,,North America,Name of the continent.
+1.11.0-dev,TRUE,server,server.geo.country_iso_code,keyword,core,,CA,Country ISO code.
+1.11.0-dev,TRUE,server,server.geo.country_name,keyword,core,,Canada,Country name.
+1.11.0-dev,TRUE,server,server.geo.location,geo_point,core,,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
+1.11.0-dev,TRUE,server,server.geo.name,keyword,extended,,boston-dc,User-defined description of a location.
+1.11.0-dev,TRUE,server,server.geo.postal_code,keyword,core,,94040,Postal code.
+1.11.0-dev,TRUE,server,server.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
+1.11.0-dev,TRUE,server,server.geo.region_name,keyword,core,,Quebec,Region name.
+1.11.0-dev,TRUE,server,server.geo.timezone,keyword,core,,America/Argentina/Buenos_Aires,Time zone.
+1.11.0-dev,TRUE,server,server.ip,ip,core,,,IP address of the server.
+1.11.0-dev,TRUE,server,server.mac,keyword,core,,00-00-5E-00-53-23,MAC address of the server.
+1.11.0-dev,TRUE,server,server.nat.ip,ip,extended,,,Server NAT ip
+1.11.0-dev,TRUE,server,server.nat.port,long,extended,,,Server NAT port
+1.11.0-dev,TRUE,server,server.packets,long,core,,12,Packets sent from the server to the client.
+1.11.0-dev,TRUE,server,server.port,long,core,,,Port of the server.
+1.11.0-dev,TRUE,server,server.registered_domain,keyword,extended,,example.com,"The highest registered server domain, stripped of the subdomain."
+1.11.0-dev,TRUE,server,server.subdomain,keyword,extended,,east,The subdomain of the domain.
+1.11.0-dev,TRUE,server,server.top_level_domain,keyword,extended,,co.uk,"The effective top level domain (com, org, net, co.uk)."
+1.11.0-dev,TRUE,server,server.user.domain,keyword,extended,,,Name of the directory the user is a member of.
+1.11.0-dev,TRUE,server,server.user.email,keyword,extended,,,User email address.
+1.11.0-dev,TRUE,server,server.user.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
+1.11.0-dev,TRUE,server,server.user.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
+1.11.0-dev,TRUE,server,server.user.group.domain,keyword,extended,,,Name of the directory the group is a member of.
+1.11.0-dev,TRUE,server,server.user.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
+1.11.0-dev,TRUE,server,server.user.group.name,keyword,extended,,,Name of the group.
+1.11.0-dev,TRUE,server,server.user.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
+1.11.0-dev,TRUE,server,server.user.id,keyword,core,,,Unique identifier of the user.
+1.11.0-dev,TRUE,server,server.user.name,keyword,core,,albert,Short name or login of the user.
+1.11.0-dev,TRUE,server,server.user.name.text,text,core,,albert,Short name or login of the user.
+1.11.0-dev,TRUE,server,server.user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
+1.11.0-dev,TRUE,service,service.ephemeral_id,keyword,extended,,8a4f500f,Ephemeral identifier of this service.
+1.11.0-dev,TRUE,service,service.id,keyword,core,,d37e5ebfe0ae6c4972dbe9f0174a1637bb8247f6,Unique identifier of the running service.
+1.11.0-dev,TRUE,service,service.name,keyword,core,,elasticsearch-metrics,Name of the service.
+1.11.0-dev,TRUE,service,service.node.name,keyword,extended,,instance-0000000016,Name of the service node.
+1.11.0-dev,TRUE,service,service.state,keyword,core,,,Current state of the service.
+1.11.0-dev,TRUE,service,service.type,keyword,core,,elasticsearch,The type of the service.
+1.11.0-dev,TRUE,service,service.version,keyword,core,,3.2.4,Version of the service.
+1.11.0-dev,TRUE,source,source.address,keyword,extended,,,Source network address.
+1.11.0-dev,TRUE,source,source.as.number,long,extended,,15169,Unique number allocated to the autonomous system.
+1.11.0-dev,TRUE,source,source.as.organization.name,keyword,extended,,Google LLC,Organization name.
+1.11.0-dev,TRUE,source,source.as.organization.name.text,text,extended,,Google LLC,Organization name.
+1.11.0-dev,TRUE,source,source.bytes,long,core,,184,Bytes sent from the source to the destination.
+1.11.0-dev,TRUE,source,source.domain,keyword,core,,,Source domain.
+1.11.0-dev,TRUE,source,source.geo.city_name,keyword,core,,Montreal,City name.
+1.11.0-dev,TRUE,source,source.geo.continent_code,keyword,core,,NA,Continent code.
+1.11.0-dev,TRUE,source,source.geo.continent_name,keyword,core,,North America,Name of the continent.
+1.11.0-dev,TRUE,source,source.geo.country_iso_code,keyword,core,,CA,Country ISO code.
+1.11.0-dev,TRUE,source,source.geo.country_name,keyword,core,,Canada,Country name.
+1.11.0-dev,TRUE,source,source.geo.location,geo_point,core,,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
+1.11.0-dev,TRUE,source,source.geo.name,keyword,extended,,boston-dc,User-defined description of a location.
+1.11.0-dev,TRUE,source,source.geo.postal_code,keyword,core,,94040,Postal code.
+1.11.0-dev,TRUE,source,source.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
+1.11.0-dev,TRUE,source,source.geo.region_name,keyword,core,,Quebec,Region name.
+1.11.0-dev,TRUE,source,source.geo.timezone,keyword,core,,America/Argentina/Buenos_Aires,Time zone.
+1.11.0-dev,TRUE,source,source.ip,ip,core,,,IP address of the source.
+1.11.0-dev,TRUE,source,source.mac,keyword,core,,00-00-5E-00-53-23,MAC address of the source.
+1.11.0-dev,TRUE,source,source.nat.ip,ip,extended,,,Source NAT ip
+1.11.0-dev,TRUE,source,source.nat.port,long,extended,,,Source NAT port
+1.11.0-dev,TRUE,source,source.packets,long,core,,12,Packets sent from the source to the destination.
+1.11.0-dev,TRUE,source,source.port,long,core,,,Port of the source.
+1.11.0-dev,TRUE,source,source.registered_domain,keyword,extended,,example.com,"The highest registered source domain, stripped of the subdomain."
+1.11.0-dev,TRUE,source,source.subdomain,keyword,extended,,east,The subdomain of the domain.
+1.11.0-dev,TRUE,source,source.top_level_domain,keyword,extended,,co.uk,"The effective top level domain (com, org, net, co.uk)."
+1.11.0-dev,TRUE,source,source.user.domain,keyword,extended,,,Name of the directory the user is a member of.
+1.11.0-dev,TRUE,source,source.user.email,keyword,extended,,,User email address.
+1.11.0-dev,TRUE,source,source.user.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
+1.11.0-dev,TRUE,source,source.user.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
+1.11.0-dev,TRUE,source,source.user.group.domain,keyword,extended,,,Name of the directory the group is a member of.
+1.11.0-dev,TRUE,source,source.user.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
+1.11.0-dev,TRUE,source,source.user.group.name,keyword,extended,,,Name of the group.
+1.11.0-dev,TRUE,source,source.user.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
+1.11.0-dev,TRUE,source,source.user.id,keyword,core,,,Unique identifier of the user.
+1.11.0-dev,TRUE,source,source.user.name,keyword,core,,albert,Short name or login of the user.
+1.11.0-dev,TRUE,source,source.user.name.text,text,core,,albert,Short name or login of the user.
+1.11.0-dev,TRUE,source,source.user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
+1.11.0-dev,TRUE,span,span.id,keyword,extended,,3ff9a8981b7ccd5a,Unique identifier of the span within the scope of its trace.
+1.11.0-dev,TRUE,threat,threat.enrichments,nested,extended,,,List of objects containing indicators enriching the event.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator,object,extended,,,Object containing indicators enriching the event.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.as.number,long,extended,,15169,Unique number allocated to the autonomous system.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.as.organization.name,keyword,extended,,Google LLC,Organization name.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.as.organization.name.text,text,extended,,Google LLC,Organization name.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.confidence,keyword,extended,,High,Indicator confidence rating
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.description,keyword,extended,,IP x.x.x.x was observed delivering the Angler EK.,Indicator description
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.email.address,keyword,extended,,phish@example.com,Indicator email address
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.accessed,date,extended,,,Last time the file was accessed.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.attributes,keyword,extended,array,"[""readonly"", ""system""]",Array of file attributes.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.code_signature.exists,boolean,core,,TRUE,Boolean to capture if a signature is present.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.code_signature.trusted,boolean,extended,,TRUE,Stores the trust status of the certificate chain.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.code_signature.valid,boolean,extended,,TRUE,Boolean to capture if the digital signature is verified against the binary content.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.created,date,extended,,,File creation time.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.ctime,date,extended,,,Last time the file attributes or metadata changed.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.device,keyword,extended,,sda,Device that is the source of the file.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.directory,keyword,extended,,/home/alice,Directory where the file is located.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.drive_letter,keyword,extended,,C,Drive letter where the file is located.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.elf.architecture,keyword,extended,,x86-64,Machine architecture of the ELF file.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.elf.byte_order,keyword,extended,,Little Endian,Byte sequence of ELF file.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.elf.cpu_type,keyword,extended,,Intel,CPU type of the ELF file.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.elf.creation_date,date,extended,,,Build or compile date.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.elf.exports,flattened,extended,array,,List of exported element names and types.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.elf.header.abi_version,keyword,extended,,,Version of the ELF Application Binary Interface (ABI).
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.elf.header.class,keyword,extended,,,Header class of the ELF file.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.elf.header.data,keyword,extended,,,Data table of the ELF header.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.elf.header.entrypoint,long,extended,,,Header entrypoint of the ELF file.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.elf.header.object_version,keyword,extended,,,"""0x1"" for original ELF files."
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.elf.header.os_abi,keyword,extended,,,Application Binary Interface (ABI) of the Linux OS.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.elf.header.type,keyword,extended,,,Header type of the ELF file.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.elf.header.version,keyword,extended,,,Version of the ELF header.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.elf.imports,flattened,extended,array,,List of imported element names and types.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.elf.sections,nested,extended,array,,Section information of the ELF file.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.elf.sections.chi2,long,extended,,,Chi-square probability distribution of the section.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.elf.sections.entropy,long,extended,,,Shannon entropy calculation from the section.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.elf.sections.flags,keyword,extended,,,ELF Section List flags.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.elf.sections.name,keyword,extended,,,ELF Section List name.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.elf.sections.physical_offset,keyword,extended,,,ELF Section List offset.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.elf.sections.physical_size,long,extended,,,ELF Section List physical size.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.elf.sections.type,keyword,extended,,,ELF Section List type.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.elf.sections.virtual_address,long,extended,,,ELF Section List virtual address.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.elf.sections.virtual_size,long,extended,,,ELF Section List virtual size.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.elf.segments,nested,extended,array,,ELF object segment list.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.elf.segments.sections,keyword,extended,,,ELF object segment sections.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.elf.segments.type,keyword,extended,,,ELF object segment type.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.elf.shared_libraries,keyword,extended,array,,List of shared libraries used by this ELF object.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.elf.telfhash,keyword,extended,,,telfhash hash for ELF file.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.extension,keyword,extended,,png,"File extension, excluding the leading dot."
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.gid,keyword,extended,,1001,Primary group ID (GID) of the file.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.group,keyword,extended,,alice,Primary group name of the file.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.inode,keyword,extended,,256383,Inode representing the file in the filesystem.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.mime_type,keyword,extended,,,"Media type of file, document, or arrangement of bytes."
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.mode,keyword,extended,,640,Mode of the file in octal representation.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.mtime,date,extended,,,Last time the file content was modified.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.name,keyword,extended,,example.png,"Name of the file including the extension, without the directory."
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.owner,keyword,extended,,alice,File owner's username.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.path,keyword,extended,,/home/alice/example.png,"Full path to the file, including the file name."
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.path.text,text,extended,,/home/alice/example.png,"Full path to the file, including the file name."
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.size,long,extended,,16384,File size in bytes.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.target_path,keyword,extended,,,Target path for symlinks.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.target_path.text,text,extended,,,Target path for symlinks.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.type,keyword,extended,,file,"File type (file, dir, or symlink)."
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.file.uid,keyword,extended,,1001,The user ID (UID) or security identifier (SID) of the file owner.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.first_seen,date,extended,,2020-11-05T17:25:47.000Z,Date/time indicator was first reported.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.geo.city_name,keyword,core,,Montreal,City name.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.geo.continent_code,keyword,core,,NA,Continent code.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.geo.continent_name,keyword,core,,North America,Name of the continent.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.geo.country_iso_code,keyword,core,,CA,Country ISO code.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.geo.country_name,keyword,core,,Canada,Country name.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.geo.location,geo_point,core,,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.geo.name,keyword,extended,,boston-dc,User-defined description of a location.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.geo.postal_code,keyword,core,,94040,Postal code.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.geo.region_name,keyword,core,,Quebec,Region name.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.geo.timezone,keyword,core,,America/Argentina/Buenos_Aires,Time zone.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.hash.md5,keyword,extended,,,MD5 hash.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.hash.sha1,keyword,extended,,,SHA1 hash.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.hash.sha256,keyword,extended,,,SHA256 hash.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.hash.sha512,keyword,extended,,,SHA512 hash.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.hash.ssdeep,keyword,extended,,,SSDEEP hash.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.ip,ip,extended,,1.2.3.4,Indicator IP address
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.last_seen,date,extended,,2020-11-05T17:25:47.000Z,Date/time indicator was last reported.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.marking.tlp,keyword,extended,,White,Indicator TLP marking
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.modified_at,date,extended,,2020-11-05T17:25:47.000Z,Date/time indicator was last updated.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.pe.architecture,keyword,extended,,x64,CPU architecture target for the file.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.pe.company,keyword,extended,,Microsoft Corporation,"Internal company name of the file, provided at compile-time."
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.pe.description,keyword,extended,,Paint,"Internal description of the file, provided at compile-time."
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.pe.file_version,keyword,extended,,6.3.9600.17415,Process name.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.pe.imphash,keyword,extended,,0c6803c4e922103c4dca5963aad36ddf,A hash of the imports in a PE file.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.pe.original_file_name,keyword,extended,,MSPAINT.EXE,"Internal name of the file, provided at compile-time."
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.pe.product,keyword,extended,,MicrosoftÂ® WindowsÂ® Operating System,"Internal product name of the file, provided at compile-time."
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.port,long,extended,,443,Indicator port
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.provider,keyword,extended,,lrz_urlhaus,Indicator provider
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.reference,keyword,extended,,https://system.example.com/indicator/0001234,Indicator reference URL
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.registry.data.bytes,keyword,extended,,ZQBuAC0AVQBTAAAAZQBuAAAAAAA=,Original bytes written with base64 encoding.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.registry.data.strings,keyword,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.registry.data.type,keyword,core,,REG_SZ,Standard registry type for encoding contents
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.registry.hive,keyword,core,,HKLM,Abbreviated name for the hive.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.registry.key,keyword,core,,SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\winword.exe,Hive-relative path of keys.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.registry.path,keyword,core,,HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\winword.exe\Debugger,"Full path, including hive, key and value"
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.registry.value,keyword,core,,Debugger,Name of the value written.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.scanner_stats,long,extended,,4,Scanner statistics
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.sightings,long,extended,,20,Number of times indicator observed
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.type,keyword,extended,,ipv4-addr,Type of indicator
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.url.domain,keyword,extended,,www.elastic.co,Domain of the url.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.url.extension,keyword,extended,,png,"File extension from the request url, excluding the leading dot."
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.url.fragment,keyword,extended,,,Portion of the url after the `#`.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.url.full,keyword,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.url.full.text,text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.url.original,keyword,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.url.original.text,text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.url.password,keyword,extended,,,Password of the request.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.url.path,keyword,extended,,,"Path of the request, such as ""/search""."
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.url.port,long,extended,,443,"Port of the request, such as 443."
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.url.query,keyword,extended,,,Query string of the request.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.url.registered_domain,keyword,extended,,example.com,"The highest registered url domain, stripped of the subdomain."
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.url.scheme,keyword,extended,,https,Scheme of the url.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.url.subdomain,keyword,extended,,east,The subdomain of the domain.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.url.top_level_domain,keyword,extended,,co.uk,"The effective top level domain (com, org, net, co.uk)."
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.url.username,keyword,extended,,,Username of the request.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.x509.alternative_names,keyword,extended,array,*.elastic.co,List of subject alternative names (SAN).
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.x509.issuer.common_name,keyword,extended,array,Example SHA2 High Assurance Server CA,List of common name (CN) of issuing certificate authority.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.x509.issuer.country,keyword,extended,array,US,List of country (C) codes
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.x509.issuer.distinguished_name,keyword,extended,,"C=US, O=Example Inc, OU=www.example.com, CN=Example SHA2 High Assurance Server CA",Distinguished name (DN) of issuing certificate authority.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.x509.issuer.locality,keyword,extended,array,Mountain View,List of locality names (L)
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.x509.issuer.organization,keyword,extended,array,Example Inc,List of organizations (O) of issuing certificate authority.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.x509.issuer.organizational_unit,keyword,extended,array,www.example.com,List of organizational units (OU) of issuing certificate authority.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.x509.issuer.state_or_province,keyword,extended,array,California,"List of state or province names (ST, S, or P)"
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.x509.not_after,date,extended,,2020-07-16 03:15:39+00:00,Time at which the certificate is no longer considered valid.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.x509.not_before,date,extended,,2019-08-16 01:40:25+00:00,Time at which the certificate is first considered valid.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.x509.public_key_algorithm,keyword,extended,,RSA,Algorithm used to generate the public key.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.x509.public_key_curve,keyword,extended,,nistp521,The curve used by the elliptic curve public key algorithm. This is algorithm specific.
+1.11.0-dev,FALSE,threat,threat.enrichments.indicator.x509.public_key_exponent,long,extended,,65537,Exponent used to derive the public key. This is algorithm specific.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.x509.public_key_size,long,extended,,2048,The size of the public key space in bits.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.x509.serial_number,keyword,extended,,55FBB9C7DEBF09809D12CCAA,Unique serial number issued by the certificate authority.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.x509.signature_algorithm,keyword,extended,,SHA256-RSA,Identifier for certificate signature algorithm.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.x509.subject.common_name,keyword,extended,array,shared.global.example.net,List of common names (CN) of subject.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.x509.subject.country,keyword,extended,array,US,List of country (C) code
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.x509.subject.distinguished_name,keyword,extended,,"C=US, ST=California, L=San Francisco, O=Example, Inc., CN=shared.global.example.net",Distinguished name (DN) of the certificate subject entity.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.x509.subject.locality,keyword,extended,array,San Francisco,List of locality names (L)
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.x509.subject.organization,keyword,extended,array,"Example, Inc.",List of organizations (O) of subject.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.x509.subject.organizational_unit,keyword,extended,array,,List of organizational units (OU) of subject.
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.x509.subject.state_or_province,keyword,extended,array,California,"List of state or province names (ST, S, or P)"
+1.11.0-dev,TRUE,threat,threat.enrichments.indicator.x509.version_number,keyword,extended,,3,Version of x509 format.
+1.11.0-dev,TRUE,threat,threat.enrichments.matched.atomic,keyword,extended,,bad-domain.com,Matched indicator value
+1.11.0-dev,TRUE,threat,threat.enrichments.matched.field,keyword,extended,,file.hash.sha256,Matched indicator field
+1.11.0-dev,TRUE,threat,threat.enrichments.matched.id,keyword,extended,,ff93aee5-86a1-4a61-b0e6-0cdc313d01b5,Matched indicator identifier
+1.11.0-dev,TRUE,threat,threat.enrichments.matched.index,keyword,extended,,filebeat-8.0.0-2021.05.23-000011,Matched indicator index
+1.11.0-dev,TRUE,threat,threat.enrichments.matched.type,keyword,extended,,indicator_match_rule,Type of indicator match
+1.11.0-dev,TRUE,threat,threat.framework,keyword,extended,,MITRE ATT&CK,Threat classification framework.
+1.11.0-dev,TRUE,threat,threat.group.alias,keyword,extended,array,"[ ""Magecart Group 6"" ]",Alias of the group.
+1.11.0-dev,TRUE,threat,threat.group.id,keyword,extended,,G0037,ID of the group.
+1.11.0-dev,TRUE,threat,threat.group.name,keyword,extended,,FIN6,Name of the group.
+1.11.0-dev,TRUE,threat,threat.group.reference,keyword,extended,,https://attack.mitre.org/groups/G0037/,Reference URL of the group.
+1.11.0-dev,TRUE,threat,threat.indicator.as.number,long,extended,,15169,Unique number allocated to the autonomous system.
+1.11.0-dev,TRUE,threat,threat.indicator.as.organization.name,keyword,extended,,Google LLC,Organization name.
+1.11.0-dev,TRUE,threat,threat.indicator.as.organization.name.text,text,extended,,Google LLC,Organization name.
+1.11.0-dev,TRUE,threat,threat.indicator.confidence,keyword,extended,,High,Indicator confidence rating
+1.11.0-dev,TRUE,threat,threat.indicator.description,keyword,extended,,IP x.x.x.x was observed delivering the Angler EK.,Indicator description
+1.11.0-dev,TRUE,threat,threat.indicator.email.address,keyword,extended,,phish@example.com,Indicator email address
+1.11.0-dev,TRUE,threat,threat.indicator.file.accessed,date,extended,,,Last time the file was accessed.
+1.11.0-dev,TRUE,threat,threat.indicator.file.attributes,keyword,extended,array,"[""readonly"", ""system""]",Array of file attributes.
+1.11.0-dev,TRUE,threat,threat.indicator.file.code_signature.exists,boolean,core,,TRUE,Boolean to capture if a signature is present.
+1.11.0-dev,TRUE,threat,threat.indicator.file.code_signature.signing_id,keyword,extended,,com.apple.xpc.proxy,The identifier used to sign the process.
+1.11.0-dev,TRUE,threat,threat.indicator.file.code_signature.status,keyword,extended,,ERROR_UNTRUSTED_ROOT,Additional information about the certificate status.
+1.11.0-dev,TRUE,threat,threat.indicator.file.code_signature.subject_name,keyword,core,,Microsoft Corporation,Subject name of the code signer
+1.11.0-dev,TRUE,threat,threat.indicator.file.code_signature.team_id,keyword,extended,,EQHXZ8M8AV,The team identifier used to sign the process.
+1.11.0-dev,TRUE,threat,threat.indicator.file.code_signature.trusted,boolean,extended,,TRUE,Stores the trust status of the certificate chain.
+1.11.0-dev,TRUE,threat,threat.indicator.file.code_signature.valid,boolean,extended,,TRUE,Boolean to capture if the digital signature is verified against the binary content.
+1.11.0-dev,TRUE,threat,threat.indicator.file.created,date,extended,,,File creation time.
+1.11.0-dev,TRUE,threat,threat.indicator.file.ctime,date,extended,,,Last time the file attributes or metadata changed.
+1.11.0-dev,TRUE,threat,threat.indicator.file.device,keyword,extended,,sda,Device that is the source of the file.
+1.11.0-dev,TRUE,threat,threat.indicator.file.directory,keyword,extended,,/home/alice,Directory where the file is located.
+1.11.0-dev,TRUE,threat,threat.indicator.file.drive_letter,keyword,extended,,C,Drive letter where the file is located.
+1.11.0-dev,TRUE,threat,threat.indicator.file.elf.architecture,keyword,extended,,x86-64,Machine architecture of the ELF file.
+1.11.0-dev,TRUE,threat,threat.indicator.file.elf.byte_order,keyword,extended,,Little Endian,Byte sequence of ELF file.
+1.11.0-dev,TRUE,threat,threat.indicator.file.elf.cpu_type,keyword,extended,,Intel,CPU type of the ELF file.
+1.11.0-dev,TRUE,threat,threat.indicator.file.elf.creation_date,date,extended,,,Build or compile date.
+1.11.0-dev,TRUE,threat,threat.indicator.file.elf.exports,flattened,extended,array,,List of exported element names and types.
+1.11.0-dev,TRUE,threat,threat.indicator.file.elf.header.abi_version,keyword,extended,,,Version of the ELF Application Binary Interface (ABI).
+1.11.0-dev,TRUE,threat,threat.indicator.file.elf.header.class,keyword,extended,,,Header class of the ELF file.
+1.11.0-dev,TRUE,threat,threat.indicator.file.elf.header.data,keyword,extended,,,Data table of the ELF header.
+1.11.0-dev,TRUE,threat,threat.indicator.file.elf.header.entrypoint,long,extended,,,Header entrypoint of the ELF file.
+1.11.0-dev,TRUE,threat,threat.indicator.file.elf.header.object_version,keyword,extended,,,"""0x1"" for original ELF files."
+1.11.0-dev,TRUE,threat,threat.indicator.file.elf.header.os_abi,keyword,extended,,,Application Binary Interface (ABI) of the Linux OS.
+1.11.0-dev,TRUE,threat,threat.indicator.file.elf.header.type,keyword,extended,,,Header type of the ELF file.
+1.11.0-dev,TRUE,threat,threat.indicator.file.elf.header.version,keyword,extended,,,Version of the ELF header.
+1.11.0-dev,TRUE,threat,threat.indicator.file.elf.imports,flattened,extended,array,,List of imported element names and types.
+1.11.0-dev,TRUE,threat,threat.indicator.file.elf.sections,nested,extended,array,,Section information of the ELF file.
+1.11.0-dev,TRUE,threat,threat.indicator.file.elf.sections.chi2,long,extended,,,Chi-square probability distribution of the section.
+1.11.0-dev,TRUE,threat,threat.indicator.file.elf.sections.entropy,long,extended,,,Shannon entropy calculation from the section.
+1.11.0-dev,TRUE,threat,threat.indicator.file.elf.sections.flags,keyword,extended,,,ELF Section List flags.
+1.11.0-dev,TRUE,threat,threat.indicator.file.elf.sections.name,keyword,extended,,,ELF Section List name.
+1.11.0-dev,TRUE,threat,threat.indicator.file.elf.sections.physical_offset,keyword,extended,,,ELF Section List offset.
+1.11.0-dev,TRUE,threat,threat.indicator.file.elf.sections.physical_size,long,extended,,,ELF Section List physical size.
+1.11.0-dev,TRUE,threat,threat.indicator.file.elf.sections.type,keyword,extended,,,ELF Section List type.
+1.11.0-dev,TRUE,threat,threat.indicator.file.elf.sections.virtual_address,long,extended,,,ELF Section List virtual address.
+1.11.0-dev,TRUE,threat,threat.indicator.file.elf.sections.virtual_size,long,extended,,,ELF Section List virtual size.
+1.11.0-dev,TRUE,threat,threat.indicator.file.elf.segments,nested,extended,array,,ELF object segment list.
+1.11.0-dev,TRUE,threat,threat.indicator.file.elf.segments.sections,keyword,extended,,,ELF object segment sections.
+1.11.0-dev,TRUE,threat,threat.indicator.file.elf.segments.type,keyword,extended,,,ELF object segment type.
+1.11.0-dev,TRUE,threat,threat.indicator.file.elf.shared_libraries,keyword,extended,array,,List of shared libraries used by this ELF object.
+1.11.0-dev,TRUE,threat,threat.indicator.file.elf.telfhash,keyword,extended,,,telfhash hash for ELF file.
+1.11.0-dev,TRUE,threat,threat.indicator.file.extension,keyword,extended,,png,"File extension, excluding the leading dot."
+1.11.0-dev,TRUE,threat,threat.indicator.file.gid,keyword,extended,,1001,Primary group ID (GID) of the file.
+1.11.0-dev,TRUE,threat,threat.indicator.file.group,keyword,extended,,alice,Primary group name of the file.
+1.11.0-dev,TRUE,threat,threat.indicator.file.inode,keyword,extended,,256383,Inode representing the file in the filesystem.
+1.11.0-dev,TRUE,threat,threat.indicator.file.mime_type,keyword,extended,,,"Media type of file, document, or arrangement of bytes."
+1.11.0-dev,TRUE,threat,threat.indicator.file.mode,keyword,extended,,640,Mode of the file in octal representation.
+1.11.0-dev,TRUE,threat,threat.indicator.file.mtime,date,extended,,,Last time the file content was modified.
+1.11.0-dev,TRUE,threat,threat.indicator.file.name,keyword,extended,,example.png,"Name of the file including the extension, without the directory."
+1.11.0-dev,TRUE,threat,threat.indicator.file.owner,keyword,extended,,alice,File owner's username.
+1.11.0-dev,TRUE,threat,threat.indicator.file.path,keyword,extended,,/home/alice/example.png,"Full path to the file, including the file name."
+1.11.0-dev,TRUE,threat,threat.indicator.file.path.text,text,extended,,/home/alice/example.png,"Full path to the file, including the file name."
+1.11.0-dev,TRUE,threat,threat.indicator.file.size,long,extended,,16384,File size in bytes.
+1.11.0-dev,TRUE,threat,threat.indicator.file.target_path,keyword,extended,,,Target path for symlinks.
+1.11.0-dev,TRUE,threat,threat.indicator.file.target_path.text,text,extended,,,Target path for symlinks.
+1.11.0-dev,TRUE,threat,threat.indicator.file.type,keyword,extended,,file,"File type (file, dir, or symlink)."
+1.11.0-dev,TRUE,threat,threat.indicator.file.uid,keyword,extended,,1001,The user ID (UID) or security identifier (SID) of the file owner.
+1.11.0-dev,TRUE,threat,threat.indicator.first_seen,date,extended,,2020-11-05T17:25:47.000Z,Date/time indicator was first reported.
+1.11.0-dev,TRUE,threat,threat.indicator.geo.city_name,keyword,core,,Montreal,City name.
+1.11.0-dev,TRUE,threat,threat.indicator.geo.continent_code,keyword,core,,NA,Continent code.
+1.11.0-dev,TRUE,threat,threat.indicator.geo.continent_name,keyword,core,,North America,Name of the continent.
+1.11.0-dev,TRUE,threat,threat.indicator.geo.country_iso_code,keyword,core,,CA,Country ISO code.
+1.11.0-dev,TRUE,threat,threat.indicator.geo.country_name,keyword,core,,Canada,Country name.
+1.11.0-dev,TRUE,threat,threat.indicator.geo.location,geo_point,core,,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
+1.11.0-dev,TRUE,threat,threat.indicator.geo.name,keyword,extended,,boston-dc,User-defined description of a location.
+1.11.0-dev,TRUE,threat,threat.indicator.geo.postal_code,keyword,core,,94040,Postal code.
+1.11.0-dev,TRUE,threat,threat.indicator.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
+1.11.0-dev,TRUE,threat,threat.indicator.geo.region_name,keyword,core,,Quebec,Region name.
+1.11.0-dev,TRUE,threat,threat.indicator.geo.timezone,keyword,core,,America/Argentina/Buenos_Aires,Time zone.
+1.11.0-dev,TRUE,threat,threat.indicator.hash.md5,keyword,extended,,,MD5 hash.
+1.11.0-dev,TRUE,threat,threat.indicator.hash.sha1,keyword,extended,,,SHA1 hash.
+1.11.0-dev,TRUE,threat,threat.indicator.hash.sha256,keyword,extended,,,SHA256 hash.
+1.11.0-dev,TRUE,threat,threat.indicator.hash.sha512,keyword,extended,,,SHA512 hash.
+1.11.0-dev,TRUE,threat,threat.indicator.hash.ssdeep,keyword,extended,,,SSDEEP hash.
+1.11.0-dev,TRUE,threat,threat.indicator.ip,ip,extended,,1.2.3.4,Indicator IP address
+1.11.0-dev,TRUE,threat,threat.indicator.last_seen,date,extended,,2020-11-05T17:25:47.000Z,Date/time indicator was last reported.
+1.11.0-dev,TRUE,threat,threat.indicator.marking.tlp,keyword,extended,,WHITE,Indicator TLP marking
+1.11.0-dev,TRUE,threat,threat.indicator.modified_at,date,extended,,2020-11-05T17:25:47.000Z,Date/time indicator was last updated.
+1.11.0-dev,TRUE,threat,threat.indicator.pe.architecture,keyword,extended,,x64,CPU architecture target for the file.
+1.11.0-dev,TRUE,threat,threat.indicator.pe.company,keyword,extended,,Microsoft Corporation,"Internal company name of the file, provided at compile-time."
+1.11.0-dev,TRUE,threat,threat.indicator.pe.description,keyword,extended,,Paint,"Internal description of the file, provided at compile-time."
+1.11.0-dev,TRUE,threat,threat.indicator.pe.file_version,keyword,extended,,6.3.9600.17415,Process name.
+1.11.0-dev,TRUE,threat,threat.indicator.pe.imphash,keyword,extended,,0c6803c4e922103c4dca5963aad36ddf,A hash of the imports in a PE file.
+1.11.0-dev,TRUE,threat,threat.indicator.pe.original_file_name,keyword,extended,,MSPAINT.EXE,"Internal name of the file, provided at compile-time."
+1.11.0-dev,TRUE,threat,threat.indicator.pe.product,keyword,extended,,MicrosoftÂ® WindowsÂ® Operating System,"Internal product name of the file, provided at compile-time."
+1.11.0-dev,TRUE,threat,threat.indicator.port,long,extended,,443,Indicator port
+1.11.0-dev,TRUE,threat,threat.indicator.provider,keyword,extended,,lrz_urlhaus,Indicator provider
+1.11.0-dev,TRUE,threat,threat.indicator.reference,keyword,extended,,https://system.example.com/indicator/0001234,Indicator reference URL
+1.11.0-dev,TRUE,threat,threat.indicator.registry.data.bytes,keyword,extended,,ZQBuAC0AVQBTAAAAZQBuAAAAAAA=,Original bytes written with base64 encoding.
+1.11.0-dev,TRUE,threat,threat.indicator.registry.data.strings,keyword,core,array,"[""C:\rta\red_ttp\bin\myapp.exe""]",List of strings representing what was written to the registry.
+1.11.0-dev,TRUE,threat,threat.indicator.registry.data.type,keyword,core,,REG_SZ,Standard registry type for encoding contents
+1.11.0-dev,TRUE,threat,threat.indicator.registry.hive,keyword,core,,HKLM,Abbreviated name for the hive.
+1.11.0-dev,TRUE,threat,threat.indicator.registry.key,keyword,core,,SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\winword.exe,Hive-relative path of keys.
+1.11.0-dev,TRUE,threat,threat.indicator.registry.path,keyword,core,,HKLM\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Image File Execution Options\winword.exe\Debugger,"Full path, including hive, key and value"
+1.11.0-dev,TRUE,threat,threat.indicator.registry.value,keyword,core,,Debugger,Name of the value written.
+1.11.0-dev,TRUE,threat,threat.indicator.scanner_stats,long,extended,,4,Scanner statistics
+1.11.0-dev,TRUE,threat,threat.indicator.sightings,long,extended,,20,Number of times indicator observed
+1.11.0-dev,TRUE,threat,threat.indicator.type,keyword,extended,,ipv4-addr,Type of indicator
+1.11.0-dev,TRUE,threat,threat.indicator.url.domain,keyword,extended,,www.elastic.co,Domain of the url.
+1.11.0-dev,TRUE,threat,threat.indicator.url.extension,keyword,extended,,png,"File extension from the request url, excluding the leading dot."
+1.11.0-dev,TRUE,threat,threat.indicator.url.fragment,keyword,extended,,,Portion of the url after the `#`.
+1.11.0-dev,TRUE,threat,threat.indicator.url.full,keyword,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
+1.11.0-dev,TRUE,threat,threat.indicator.url.full.text,text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
+1.11.0-dev,TRUE,threat,threat.indicator.url.original,keyword,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
+1.11.0-dev,TRUE,threat,threat.indicator.url.original.text,text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
+1.11.0-dev,TRUE,threat,threat.indicator.url.password,keyword,extended,,,Password of the request.
+1.11.0-dev,TRUE,threat,threat.indicator.url.path,keyword,extended,,,"Path of the request, such as ""/search""."
+1.11.0-dev,TRUE,threat,threat.indicator.url.port,long,extended,,443,"Port of the request, such as 443."
+1.11.0-dev,TRUE,threat,threat.indicator.url.query,keyword,extended,,,Query string of the request.
+1.11.0-dev,TRUE,threat,threat.indicator.url.registered_domain,keyword,extended,,example.com,"The highest registered url domain, stripped of the subdomain."
+1.11.0-dev,TRUE,threat,threat.indicator.url.scheme,keyword,extended,,https,Scheme of the url.
+1.11.0-dev,TRUE,threat,threat.indicator.url.subdomain,keyword,extended,,east,The subdomain of the domain.
+1.11.0-dev,TRUE,threat,threat.indicator.url.top_level_domain,keyword,extended,,co.uk,"The effective top level domain (com, org, net, co.uk)."
+1.11.0-dev,TRUE,threat,threat.indicator.url.username,keyword,extended,,,Username of the request.
+1.11.0-dev,TRUE,threat,threat.indicator.x509.alternative_names,keyword,extended,array,*.elastic.co,List of subject alternative names (SAN).
+1.11.0-dev,TRUE,threat,threat.indicator.x509.issuer.common_name,keyword,extended,array,Example SHA2 High Assurance Server CA,List of common name (CN) of issuing certificate authority.
+1.11.0-dev,TRUE,threat,threat.indicator.x509.issuer.country,keyword,extended,array,US,List of country (C) codes
+1.11.0-dev,TRUE,threat,threat.indicator.x509.issuer.distinguished_name,keyword,extended,,"C=US, O=Example Inc, OU=www.example.com, CN=Example SHA2 High Assurance Server CA",Distinguished name (DN) of issuing certificate authority.
+1.11.0-dev,TRUE,threat,threat.indicator.x509.issuer.locality,keyword,extended,array,Mountain View,List of locality names (L)
+1.11.0-dev,TRUE,threat,threat.indicator.x509.issuer.organization,keyword,extended,array,Example Inc,List of organizations (O) of issuing certificate authority.
+1.11.0-dev,TRUE,threat,threat.indicator.x509.issuer.organizational_unit,keyword,extended,array,www.example.com,List of organizational units (OU) of issuing certificate authority.
+1.11.0-dev,TRUE,threat,threat.indicator.x509.issuer.state_or_province,keyword,extended,array,California,"List of state or province names (ST, S, or P)"
+1.11.0-dev,TRUE,threat,threat.indicator.x509.not_after,date,extended,,2020-07-16 03:15:39+00:00,Time at which the certificate is no longer considered valid.
+1.11.0-dev,TRUE,threat,threat.indicator.x509.not_before,date,extended,,2019-08-16 01:40:25+00:00,Time at which the certificate is first considered valid.
+1.11.0-dev,TRUE,threat,threat.indicator.x509.public_key_algorithm,keyword,extended,,RSA,Algorithm used to generate the public key.
+1.11.0-dev,TRUE,threat,threat.indicator.x509.public_key_curve,keyword,extended,,nistp521,The curve used by the elliptic curve public key algorithm. This is algorithm specific.
+1.11.0-dev,FALSE,threat,threat.indicator.x509.public_key_exponent,long,extended,,65537,Exponent used to derive the public key. This is algorithm specific.
+1.11.0-dev,TRUE,threat,threat.indicator.x509.public_key_size,long,extended,,2048,The size of the public key space in bits.
+1.11.0-dev,TRUE,threat,threat.indicator.x509.serial_number,keyword,extended,,55FBB9C7DEBF09809D12CCAA,Unique serial number issued by the certificate authority.
+1.11.0-dev,TRUE,threat,threat.indicator.x509.signature_algorithm,keyword,extended,,SHA256-RSA,Identifier for certificate signature algorithm.
+1.11.0-dev,TRUE,threat,threat.indicator.x509.subject.common_name,keyword,extended,array,shared.global.example.net,List of common names (CN) of subject.
+1.11.0-dev,TRUE,threat,threat.indicator.x509.subject.country,keyword,extended,array,US,List of country (C) code
+1.11.0-dev,TRUE,threat,threat.indicator.x509.subject.distinguished_name,keyword,extended,,"C=US, ST=California, L=San Francisco, O=Example, Inc., CN=shared.global.example.net",Distinguished name (DN) of the certificate subject entity.
+1.11.0-dev,TRUE,threat,threat.indicator.x509.subject.locality,keyword,extended,array,San Francisco,List of locality names (L)
+1.11.0-dev,TRUE,threat,threat.indicator.x509.subject.organization,keyword,extended,array,"Example, Inc.",List of organizations (O) of subject.
+1.11.0-dev,TRUE,threat,threat.indicator.x509.subject.organizational_unit,keyword,extended,array,,List of organizational units (OU) of subject.
+1.11.0-dev,TRUE,threat,threat.indicator.x509.subject.state_or_province,keyword,extended,array,California,"List of state or province names (ST, S, or P)"
+1.11.0-dev,TRUE,threat,threat.indicator.x509.version_number,keyword,extended,,3,Version of x509 format.
+1.11.0-dev,TRUE,threat,threat.software.id,keyword,extended,,S0552,ID of the software
+1.11.0-dev,TRUE,threat,threat.software.name,keyword,extended,,AdFind,Name of the software.
+1.11.0-dev,TRUE,threat,threat.software.platforms,keyword,extended,array,"[ ""Windows"" ]",Platforms of the software.
+1.11.0-dev,TRUE,threat,threat.software.reference,keyword,extended,,https://attack.mitre.org/software/S0552/,Software reference URL.
+1.11.0-dev,TRUE,threat,threat.software.type,keyword,extended,,Tool,Software type.
+1.11.0-dev,TRUE,threat,threat.tactic.id,keyword,extended,array,TA0002,Threat tactic id.
+1.11.0-dev,TRUE,threat,threat.tactic.name,keyword,extended,array,Execution,Threat tactic.
+1.11.0-dev,TRUE,threat,threat.tactic.reference,keyword,extended,array,https://attack.mitre.org/tactics/TA0002/,Threat tactic URL reference.
+1.11.0-dev,TRUE,threat,threat.technique.id,keyword,extended,array,T1059,Threat technique id.
+1.11.0-dev,TRUE,threat,threat.technique.name,keyword,extended,array,Command and Scripting Interpreter,Threat technique name.
+1.11.0-dev,TRUE,threat,threat.technique.name.text,text,extended,,Command and Scripting Interpreter,Threat technique name.
+1.11.0-dev,TRUE,threat,threat.technique.reference,keyword,extended,array,https://attack.mitre.org/techniques/T1059/,Threat technique URL reference.
+1.11.0-dev,TRUE,threat,threat.technique.subtechnique.id,keyword,extended,array,T1059.001,Threat subtechnique id.
+1.11.0-dev,TRUE,threat,threat.technique.subtechnique.name,keyword,extended,array,PowerShell,Threat subtechnique name.
+1.11.0-dev,TRUE,threat,threat.technique.subtechnique.name.text,text,extended,,PowerShell,Threat subtechnique name.
+1.11.0-dev,TRUE,threat,threat.technique.subtechnique.reference,keyword,extended,array,https://attack.mitre.org/techniques/T1059/001/,Threat subtechnique URL reference.
+1.11.0-dev,TRUE,tls,tls.cipher,keyword,extended,,TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,String indicating the cipher used during the current connection.
+1.11.0-dev,TRUE,tls,tls.client.certificate,keyword,extended,,MII...,PEM-encoded stand-alone certificate offered by the client.
+1.11.0-dev,TRUE,tls,tls.client.certificate_chain,keyword,extended,array,"[""MII..."", ""MII...""]",Array of PEM-encoded certificates that make up the certificate chain offered by the client.
+1.11.0-dev,TRUE,tls,tls.client.hash.md5,keyword,extended,,0F76C7F2C55BFD7D8E8B8F4BFBF0C9EC,Certificate fingerprint using the MD5 digest of DER-encoded version of certificate offered by the client.
+1.11.0-dev,TRUE,tls,tls.client.hash.sha1,keyword,extended,,9E393D93138888D288266C2D915214D1D1CCEB2A,Certificate fingerprint using the SHA1 digest of DER-encoded version of certificate offered by the client.
+1.11.0-dev,TRUE,tls,tls.client.hash.sha256,keyword,extended,,0687F666A054EF17A08E2F2162EAB4CBC0D265E1D7875BE74BF3C712CA92DAF0,Certificate fingerprint using the SHA256 digest of DER-encoded version of certificate offered by the client.
+1.11.0-dev,TRUE,tls,tls.client.issuer,keyword,extended,,"CN=Example Root CA, OU=Infrastructure Team, DC=example, DC=com",Distinguished name of subject of the issuer of the x.509 certificate presented by the client.
+1.11.0-dev,TRUE,tls,tls.client.ja3,keyword,extended,,d4e5b18d6b55c71272893221c96ba240,A hash that identifies clients based on how they perform an SSL/TLS handshake.
+1.11.0-dev,TRUE,tls,tls.client.not_after,date,extended,,2021-01-01T00:00:00.000Z,Date/Time indicating when client certificate is no longer considered valid.
+1.11.0-dev,TRUE,tls,tls.client.not_before,date,extended,,1970-01-01T00:00:00.000Z,Date/Time indicating when client certificate is first considered valid.
+1.11.0-dev,TRUE,tls,tls.client.server_name,keyword,extended,,www.elastic.co,Hostname the client is trying to connect to. Also called the SNI.
+1.11.0-dev,TRUE,tls,tls.client.subject,keyword,extended,,"CN=myclient, OU=Documentation Team, DC=example, DC=com",Distinguished name of subject of the x.509 certificate presented by the client.
+1.11.0-dev,TRUE,tls,tls.client.supported_ciphers,keyword,extended,array,"[""TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"", ""TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384"", ""...""]",Array of ciphers offered by the client during the client hello.
+1.11.0-dev,TRUE,tls,tls.client.x509.alternative_names,keyword,extended,array,*.elastic.co,List of subject alternative names (SAN).
+1.11.0-dev,TRUE,tls,tls.client.x509.issuer.common_name,keyword,extended,array,Example SHA2 High Assurance Server CA,List of common name (CN) of issuing certificate authority.
+1.11.0-dev,TRUE,tls,tls.client.x509.issuer.country,keyword,extended,array,US,List of country (C) codes
+1.11.0-dev,TRUE,tls,tls.client.x509.issuer.distinguished_name,keyword,extended,,"C=US, O=Example Inc, OU=www.example.com, CN=Example SHA2 High Assurance Server CA",Distinguished name (DN) of issuing certificate authority.
+1.11.0-dev,TRUE,tls,tls.client.x509.issuer.locality,keyword,extended,array,Mountain View,List of locality names (L)
+1.11.0-dev,TRUE,tls,tls.client.x509.issuer.organization,keyword,extended,array,Example Inc,List of organizations (O) of issuing certificate authority.
+1.11.0-dev,TRUE,tls,tls.client.x509.issuer.organizational_unit,keyword,extended,array,www.example.com,List of organizational units (OU) of issuing certificate authority.
+1.11.0-dev,TRUE,tls,tls.client.x509.issuer.state_or_province,keyword,extended,array,California,"List of state or province names (ST, S, or P)"
+1.11.0-dev,TRUE,tls,tls.client.x509.not_after,date,extended,,2020-07-16 03:15:39+00:00,Time at which the certificate is no longer considered valid.
+1.11.0-dev,TRUE,tls,tls.client.x509.not_before,date,extended,,2019-08-16 01:40:25+00:00,Time at which the certificate is first considered valid.
+1.11.0-dev,TRUE,tls,tls.client.x509.public_key_algorithm,keyword,extended,,RSA,Algorithm used to generate the public key.
+1.11.0-dev,TRUE,tls,tls.client.x509.public_key_curve,keyword,extended,,nistp521,The curve used by the elliptic curve public key algorithm. This is algorithm specific.
+1.11.0-dev,FALSE,tls,tls.client.x509.public_key_exponent,long,extended,,65537,Exponent used to derive the public key. This is algorithm specific.
+1.11.0-dev,TRUE,tls,tls.client.x509.public_key_size,long,extended,,2048,The size of the public key space in bits.
+1.11.0-dev,TRUE,tls,tls.client.x509.serial_number,keyword,extended,,55FBB9C7DEBF09809D12CCAA,Unique serial number issued by the certificate authority.
+1.11.0-dev,TRUE,tls,tls.client.x509.signature_algorithm,keyword,extended,,SHA256-RSA,Identifier for certificate signature algorithm.
+1.11.0-dev,TRUE,tls,tls.client.x509.subject.common_name,keyword,extended,array,shared.global.example.net,List of common names (CN) of subject.
+1.11.0-dev,TRUE,tls,tls.client.x509.subject.country,keyword,extended,array,US,List of country (C) code
+1.11.0-dev,TRUE,tls,tls.client.x509.subject.distinguished_name,keyword,extended,,"C=US, ST=California, L=San Francisco, O=Example, Inc., CN=shared.global.example.net",Distinguished name (DN) of the certificate subject entity.
+1.11.0-dev,TRUE,tls,tls.client.x509.subject.locality,keyword,extended,array,San Francisco,List of locality names (L)
+1.11.0-dev,TRUE,tls,tls.client.x509.subject.organization,keyword,extended,array,"Example, Inc.",List of organizations (O) of subject.
+1.11.0-dev,TRUE,tls,tls.client.x509.subject.organizational_unit,keyword,extended,array,,List of organizational units (OU) of subject.
+1.11.0-dev,TRUE,tls,tls.client.x509.subject.state_or_province,keyword,extended,array,California,"List of state or province names (ST, S, or P)"
+1.11.0-dev,TRUE,tls,tls.client.x509.version_number,keyword,extended,,3,Version of x509 format.
+1.11.0-dev,TRUE,tls,tls.curve,keyword,extended,,secp256r1,"String indicating the curve used for the given cipher, when applicable."
+1.11.0-dev,TRUE,tls,tls.established,boolean,extended,,,Boolean flag indicating if the TLS negotiation was successful and transitioned to an encrypted tunnel.
+1.11.0-dev,TRUE,tls,tls.next_protocol,keyword,extended,,http/1.1,String indicating the protocol being tunneled.
+1.11.0-dev,TRUE,tls,tls.resumed,boolean,extended,,,Boolean flag indicating if this TLS connection was resumed from an existing TLS negotiation.
+1.11.0-dev,TRUE,tls,tls.server.certificate,keyword,extended,,MII...,PEM-encoded stand-alone certificate offered by the server.
+1.11.0-dev,TRUE,tls,tls.server.certificate_chain,keyword,extended,array,"[""MII..."", ""MII...""]",Array of PEM-encoded certificates that make up the certificate chain offered by the server.
+1.11.0-dev,TRUE,tls,tls.server.hash.md5,keyword,extended,,0F76C7F2C55BFD7D8E8B8F4BFBF0C9EC,Certificate fingerprint using the MD5 digest of DER-encoded version of certificate offered by the server.
+1.11.0-dev,TRUE,tls,tls.server.hash.sha1,keyword,extended,,9E393D93138888D288266C2D915214D1D1CCEB2A,Certificate fingerprint using the SHA1 digest of DER-encoded version of certificate offered by the server.
+1.11.0-dev,TRUE,tls,tls.server.hash.sha256,keyword,extended,,0687F666A054EF17A08E2F2162EAB4CBC0D265E1D7875BE74BF3C712CA92DAF0,Certificate fingerprint using the SHA256 digest of DER-encoded version of certificate offered by the server.
+1.11.0-dev,TRUE,tls,tls.server.issuer,keyword,extended,,"CN=Example Root CA, OU=Infrastructure Team, DC=example, DC=com",Subject of the issuer of the x.509 certificate presented by the server.
+1.11.0-dev,TRUE,tls,tls.server.ja3s,keyword,extended,,394441ab65754e2207b1e1b457b3641d,A hash that identifies servers based on how they perform an SSL/TLS handshake.
+1.11.0-dev,TRUE,tls,tls.server.not_after,date,extended,,2021-01-01T00:00:00.000Z,Timestamp indicating when server certificate is no longer considered valid.
+1.11.0-dev,TRUE,tls,tls.server.not_before,date,extended,,1970-01-01T00:00:00.000Z,Timestamp indicating when server certificate is first considered valid.
+1.11.0-dev,TRUE,tls,tls.server.subject,keyword,extended,,"CN=www.example.com, OU=Infrastructure Team, DC=example, DC=com",Subject of the x.509 certificate presented by the server.
+1.11.0-dev,TRUE,tls,tls.server.x509.alternative_names,keyword,extended,array,*.elastic.co,List of subject alternative names (SAN).
+1.11.0-dev,TRUE,tls,tls.server.x509.issuer.common_name,keyword,extended,array,Example SHA2 High Assurance Server CA,List of common name (CN) of issuing certificate authority.
+1.11.0-dev,TRUE,tls,tls.server.x509.issuer.country,keyword,extended,array,US,List of country (C) codes
+1.11.0-dev,TRUE,tls,tls.server.x509.issuer.distinguished_name,keyword,extended,,"C=US, O=Example Inc, OU=www.example.com, CN=Example SHA2 High Assurance Server CA",Distinguished name (DN) of issuing certificate authority.
+1.11.0-dev,TRUE,tls,tls.server.x509.issuer.locality,keyword,extended,array,Mountain View,List of locality names (L)
+1.11.0-dev,TRUE,tls,tls.server.x509.issuer.organization,keyword,extended,array,Example Inc,List of organizations (O) of issuing certificate authority.
+1.11.0-dev,TRUE,tls,tls.server.x509.issuer.organizational_unit,keyword,extended,array,www.example.com,List of organizational units (OU) of issuing certificate authority.
+1.11.0-dev,TRUE,tls,tls.server.x509.issuer.state_or_province,keyword,extended,array,California,"List of state or province names (ST, S, or P)"
+1.11.0-dev,TRUE,tls,tls.server.x509.not_after,date,extended,,2020-07-16 03:15:39+00:00,Time at which the certificate is no longer considered valid.
+1.11.0-dev,TRUE,tls,tls.server.x509.not_before,date,extended,,2019-08-16 01:40:25+00:00,Time at which the certificate is first considered valid.
+1.11.0-dev,TRUE,tls,tls.server.x509.public_key_algorithm,keyword,extended,,RSA,Algorithm used to generate the public key.
+1.11.0-dev,TRUE,tls,tls.server.x509.public_key_curve,keyword,extended,,nistp521,The curve used by the elliptic curve public key algorithm. This is algorithm specific.
+1.11.0-dev,FALSE,tls,tls.server.x509.public_key_exponent,long,extended,,65537,Exponent used to derive the public key. This is algorithm specific.
+1.11.0-dev,TRUE,tls,tls.server.x509.public_key_size,long,extended,,2048,The size of the public key space in bits.
+1.11.0-dev,TRUE,tls,tls.server.x509.serial_number,keyword,extended,,55FBB9C7DEBF09809D12CCAA,Unique serial number issued by the certificate authority.
+1.11.0-dev,TRUE,tls,tls.server.x509.signature_algorithm,keyword,extended,,SHA256-RSA,Identifier for certificate signature algorithm.
+1.11.0-dev,TRUE,tls,tls.server.x509.subject.common_name,keyword,extended,array,shared.global.example.net,List of common names (CN) of subject.
+1.11.0-dev,TRUE,tls,tls.server.x509.subject.country,keyword,extended,array,US,List of country (C) code
+1.11.0-dev,TRUE,tls,tls.server.x509.subject.distinguished_name,keyword,extended,,"C=US, ST=California, L=San Francisco, O=Example, Inc., CN=shared.global.example.net",Distinguished name (DN) of the certificate subject entity.
+1.11.0-dev,TRUE,tls,tls.server.x509.subject.locality,keyword,extended,array,San Francisco,List of locality names (L)
+1.11.0-dev,TRUE,tls,tls.server.x509.subject.organization,keyword,extended,array,"Example, Inc.",List of organizations (O) of subject.
+1.11.0-dev,TRUE,tls,tls.server.x509.subject.organizational_unit,keyword,extended,array,,List of organizational units (OU) of subject.
+1.11.0-dev,TRUE,tls,tls.server.x509.subject.state_or_province,keyword,extended,array,California,"List of state or province names (ST, S, or P)"
+1.11.0-dev,TRUE,tls,tls.server.x509.version_number,keyword,extended,,3,Version of x509 format.
+1.11.0-dev,TRUE,tls,tls.version,keyword,extended,,1.2,Numeric part of the version parsed from the original string.
+1.11.0-dev,TRUE,tls,tls.version_protocol,keyword,extended,,tls,Normalized lowercase protocol name parsed from original string.
+1.11.0-dev,TRUE,trace,trace.id,keyword,extended,,4bf92f3577b34da6a3ce929d0e0e4736,Unique identifier of the trace.
+1.11.0-dev,TRUE,transaction,transaction.id,keyword,extended,,00f067aa0ba902b7,Unique identifier of the transaction within the scope of its trace.
+1.11.0-dev,TRUE,url,url.domain,keyword,extended,,www.elastic.co,Domain of the url.
+1.11.0-dev,TRUE,url,url.extension,keyword,extended,,png,"File extension from the request url, excluding the leading dot."
+1.11.0-dev,TRUE,url,url.fragment,keyword,extended,,,Portion of the url after the `#`.
+1.11.0-dev,TRUE,url,url.full,keyword,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
+1.11.0-dev,TRUE,url,url.full.text,text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top,Full unparsed URL.
+1.11.0-dev,TRUE,url,url.original,keyword,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
+1.11.0-dev,TRUE,url,url.original.text,text,extended,,https://www.elastic.co:443/search?q=elasticsearch#top or /search?q=elasticsearch,Unmodified original url as seen in the event source.
+1.11.0-dev,TRUE,url,url.password,keyword,extended,,,Password of the request.
+1.11.0-dev,TRUE,url,url.path,keyword,extended,,,"Path of the request, such as ""/search""."
+1.11.0-dev,TRUE,url,url.port,long,extended,,443,"Port of the request, such as 443."
+1.11.0-dev,TRUE,url,url.query,keyword,extended,,,Query string of the request.
+1.11.0-dev,TRUE,url,url.registered_domain,keyword,extended,,example.com,"The highest registered url domain, stripped of the subdomain."
+1.11.0-dev,TRUE,url,url.scheme,keyword,extended,,https,Scheme of the url.
+1.11.0-dev,TRUE,url,url.subdomain,keyword,extended,,east,The subdomain of the domain.
+1.11.0-dev,TRUE,url,url.top_level_domain,keyword,extended,,co.uk,"The effective top level domain (com, org, net, co.uk)."
+1.11.0-dev,TRUE,url,url.username,keyword,extended,,,Username of the request.
+1.11.0-dev,TRUE,user,user.changes.domain,keyword,extended,,,Name of the directory the user is a member of.
+1.11.0-dev,TRUE,user,user.changes.email,keyword,extended,,,User email address.
+1.11.0-dev,TRUE,user,user.changes.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
+1.11.0-dev,TRUE,user,user.changes.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
+1.11.0-dev,TRUE,user,user.changes.group.domain,keyword,extended,,,Name of the directory the group is a member of.
+1.11.0-dev,TRUE,user,user.changes.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
+1.11.0-dev,TRUE,user,user.changes.group.name,keyword,extended,,,Name of the group.
+1.11.0-dev,TRUE,user,user.changes.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
+1.11.0-dev,TRUE,user,user.changes.id,keyword,core,,,Unique identifier of the user.
+1.11.0-dev,TRUE,user,user.changes.name,keyword,core,,albert,Short name or login of the user.
+1.11.0-dev,TRUE,user,user.changes.name.text,text,core,,albert,Short name or login of the user.
+1.11.0-dev,TRUE,user,user.changes.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
+1.11.0-dev,TRUE,user,user.domain,keyword,extended,,,Name of the directory the user is a member of.
+1.11.0-dev,TRUE,user,user.effective.domain,keyword,extended,,,Name of the directory the user is a member of.
+1.11.0-dev,TRUE,user,user.effective.email,keyword,extended,,,User email address.
+1.11.0-dev,TRUE,user,user.effective.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
+1.11.0-dev,TRUE,user,user.effective.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
+1.11.0-dev,TRUE,user,user.effective.group.domain,keyword,extended,,,Name of the directory the group is a member of.
+1.11.0-dev,TRUE,user,user.effective.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
+1.11.0-dev,TRUE,user,user.effective.group.name,keyword,extended,,,Name of the group.
+1.11.0-dev,TRUE,user,user.effective.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
+1.11.0-dev,TRUE,user,user.effective.id,keyword,core,,,Unique identifier of the user.
+1.11.0-dev,TRUE,user,user.effective.name,keyword,core,,albert,Short name or login of the user.
+1.11.0-dev,TRUE,user,user.effective.name.text,text,core,,albert,Short name or login of the user.
+1.11.0-dev,TRUE,user,user.effective.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
+1.11.0-dev,TRUE,user,user.email,keyword,extended,,,User email address.
+1.11.0-dev,TRUE,user,user.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
+1.11.0-dev,TRUE,user,user.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
+1.11.0-dev,TRUE,user,user.group.domain,keyword,extended,,,Name of the directory the group is a member of.
+1.11.0-dev,TRUE,user,user.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
+1.11.0-dev,TRUE,user,user.group.name,keyword,extended,,,Name of the group.
+1.11.0-dev,TRUE,user,user.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
+1.11.0-dev,TRUE,user,user.id,keyword,core,,,Unique identifier of the user.
+1.11.0-dev,TRUE,user,user.name,keyword,core,,albert,Short name or login of the user.
+1.11.0-dev,TRUE,user,user.name.text,text,core,,albert,Short name or login of the user.
+1.11.0-dev,TRUE,user,user.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
+1.11.0-dev,TRUE,user,user.target.domain,keyword,extended,,,Name of the directory the user is a member of.
+1.11.0-dev,TRUE,user,user.target.email,keyword,extended,,,User email address.
+1.11.0-dev,TRUE,user,user.target.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
+1.11.0-dev,TRUE,user,user.target.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
+1.11.0-dev,TRUE,user,user.target.group.domain,keyword,extended,,,Name of the directory the group is a member of.
+1.11.0-dev,TRUE,user,user.target.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
+1.11.0-dev,TRUE,user,user.target.group.name,keyword,extended,,,Name of the group.
+1.11.0-dev,TRUE,user,user.target.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
+1.11.0-dev,TRUE,user,user.target.id,keyword,core,,,Unique identifier of the user.
+1.11.0-dev,TRUE,user,user.target.name,keyword,core,,albert,Short name or login of the user.
+1.11.0-dev,TRUE,user,user.target.name.text,text,core,,albert,Short name or login of the user.
+1.11.0-dev,TRUE,user,user.target.roles,keyword,extended,array,"[""kibana_admin"", ""reporting_user""]",Array of user roles at the time of the event.
+1.11.0-dev,TRUE,user_agent,user_agent.device.name,keyword,extended,,iPhone,Name of the device.
+1.11.0-dev,TRUE,user_agent,user_agent.name,keyword,extended,,Safari,Name of the user agent.
+1.11.0-dev,TRUE,user_agent,user_agent.original,keyword,extended,,"Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1",Unparsed user_agent string.
+1.11.0-dev,TRUE,user_agent,user_agent.original.text,text,extended,,"Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1",Unparsed user_agent string.
+1.11.0-dev,TRUE,user_agent,user_agent.os.family,keyword,extended,,debian,"OS family (such as redhat, debian, freebsd, windows)."
+1.11.0-dev,TRUE,user_agent,user_agent.os.full,keyword,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
+1.11.0-dev,TRUE,user_agent,user_agent.os.full.text,text,extended,,Mac OS Mojave,"Operating system name, including the version or code name."
+1.11.0-dev,TRUE,user_agent,user_agent.os.kernel,keyword,extended,,4.4.0-112-generic,Operating system kernel version as a raw string.
+1.11.0-dev,TRUE,user_agent,user_agent.os.name,keyword,extended,,Mac OS X,"Operating system name, without the version."
+1.11.0-dev,TRUE,user_agent,user_agent.os.name.text,text,extended,,Mac OS X,"Operating system name, without the version."
+1.11.0-dev,TRUE,user_agent,user_agent.os.platform,keyword,extended,,darwin,"Operating system platform (such centos, ubuntu, windows)."
+1.11.0-dev,TRUE,user_agent,user_agent.os.type,keyword,extended,,macos,"Which commercial OS family (one of: linux, macos, unix or windows)."
+1.11.0-dev,TRUE,user_agent,user_agent.os.version,keyword,extended,,10.14.1,Operating system version as a raw string.
+1.11.0-dev,TRUE,user_agent,user_agent.version,keyword,extended,,12,Version of the user agent.
+1.11.0-dev,TRUE,vulnerability,vulnerability.category,keyword,extended,array,"[""Firewall""]",Category of a vulnerability.
+1.11.0-dev,TRUE,vulnerability,vulnerability.classification,keyword,extended,,CVSS,Classification of the vulnerability.
+1.11.0-dev,TRUE,vulnerability,vulnerability.description,keyword,extended,,"In macOS before 2.12.6, there is a vulnerability in the RPC...",Description of the vulnerability.
+1.11.0-dev,TRUE,vulnerability,vulnerability.description.text,text,extended,,"In macOS before 2.12.6, there is a vulnerability in the RPC...",Description of the vulnerability.
+1.11.0-dev,TRUE,vulnerability,vulnerability.enumeration,keyword,extended,,CVE,Identifier of the vulnerability.
+1.11.0-dev,TRUE,vulnerability,vulnerability.id,keyword,extended,,CVE-2019-00001,ID of the vulnerability.
+1.11.0-dev,TRUE,vulnerability,vulnerability.reference,keyword,extended,,https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-6111,Reference of the vulnerability.
+1.11.0-dev,TRUE,vulnerability,vulnerability.report_id,keyword,extended,,20191018,Scan identification number.
+1.11.0-dev,TRUE,vulnerability,vulnerability.scanner.vendor,keyword,extended,,Tenable,Name of the scanner vendor.
+1.11.0-dev,TRUE,vulnerability,vulnerability.score.base,float,extended,,5.5,Vulnerability Base score.
+1.11.0-dev,TRUE,vulnerability,vulnerability.score.environmental,float,extended,,5.5,Vulnerability Environmental score.
+1.11.0-dev,TRUE,vulnerability,vulnerability.score.temporal,float,extended,,,Vulnerability Temporal score.
+1.11.0-dev,TRUE,vulnerability,vulnerability.score.version,keyword,extended,,2,CVSS version.
+1.11.0-dev,TRUE,vulnerability,vulnerability.severity,keyword,extended,,Critical,Severity of the vulnerability.
+custom,TRUE,database,database.user.email,keyword,extended,,,User email address.
+custom,TRUE,database,database.user.full_name,keyword,extended,,Albert Einstein,"User's full name, if available."
+custom,TRUE,database,database.user.full_name.text,text,extended,,Albert Einstein,"User's full name, if available."
+custom,TRUE,database,database.user.group.id,keyword,extended,,,Unique identifier for the group on the system/platform.
+custom,TRUE,database,database.user.group.name,keyword,extended,,,Name of the group.
+custom,TRUE,database,database.user.hash,keyword,extended,,,Unique user hash to correlate information for a user in anonymized form.
+custom,TRUE,database,database.user.id,keyword,extended,,,Unique identifiers of the user.
+custom,TRUE,database,database.user.name,keyword,extended,,albert,Short name or login of the user.
+custom,TRUE,database,database.user.name.text,text,extended,,albert,Short name or login of the user.
+custom,TRUE,database,database.name ,keyword,extended,,,
+custom,TRUE,database,database.instance,keyword,extended,,,
+custom,TRUE,database,database.table,keyword,extended,,,
+custom,TRUE,database,database.field_names,keyword,extended,,,
+custom,TRUE,email,email.subject,keyword,extended,,,
+custom,TRUE,agent,agent.parse_rule,keyword,extended,,,
+custom,TRUE,email,email.header,keyword,extended,,,
+custom,TRUE,log,log.source.ip,ip,extended,,,
+custom,TRUE,log,log.source.hostname,keyword,extended,,,
+custom,TRUE,email,email.src.display.name ,keyword,extended,,,
+custom,TRUE,email,email.reply.to ,keyword,extended,,,
+custom,TRUE,email,email.x.mailer,keyword,extended,,,
+custom,TRUE,email,email.body,keyword,extended,,,
+custom,TRUE,threat,threat.list.uuid,keyword,extended,,,
+custom,TRUE,threat,threat.list.category,keyword,extended,,,
+custom,TRUE,threat,threat.list.type,keyword,extended,,,
+custom,TRUE,threat,threat.list.event_id,keyword,extended,,,
+custom,TRUE,threat,threat.list.object_uuid,keyword,extended,,,
+custom,TRUE,threat,threat.list.type,keyword,extended,,,
+custom,TRUE,threat,threat.list.ioc,keyword,extended,,,
+custom,TRUE,threat,threat.list.start,date,extended,,,
+custom,TRUE,threat,threat.list.created,date,extended,,,
+custom,TRUE,threat,threat.list.ingested,date,extended,,,
+custom,TRUE,threat,threat.list.member_org,keyword,extended,,,
+custom,TRUE,threat,threat.list.source_org,keyword,extended,,,
+custom,TRUE,threat,threat.list.event_info,keyword,extended,,,
+custom,TRUE,threat,threat.list.severity_name,keyword,extended,,,
+custom,TRUE,threat,threat.list.object_category,keyword,extended,,,
+custom,TRUE,threat,threat.list.comment,keyword,extended,,,
+custom,TRUE,threat,threat.list.event_tag,keyword,extended,,,
+custom,TRUE,threat,threat.list.safe_to_enable_ids,boolean,extended,,,
+custom,TRUE,threat,threat.list.object_relation,keyword,extended,,,
+custom,TRUE,threat,threat.list.attribute_tag,keyword,extended,,,
+custom,TRUE,threat,threat.list.object_name,keyword,extended,,,
+custom,TRUE,threat,threat.list.event_analysis,keyword,extended,,,
+custom,TRUE,threat,threat.list.distribution,keyword,extended,,,
+custom,TRUE,event,event.modified,date,extended,,,
+custom,TRUE,database,database.user.domain,keyword,extended,,,Name of the directory the user is a member of.
+custom,TRUE,event,event.severity_name,keyword,extended,,,
+custom,TRUE,network,network.mac,keyword,Custom Field,,Custom Field,MAC address of a network device.
+custom,TRUE,host,host.last_logged_in_user,keyword,Custom Field,,Custom Field,Last logged in user on a host device.
+custom,TRUE,host,host.logged_in_users,keyword,Custom Field,,Custom Field,Currently logged in users on a host device.
+custom,TRUE,host,host.manufacturer,keyword,Custom Field,,Custom Field,The manufacturer of a host device.
+custom,TRUE,host,host.model,keyword,Custom Field,,Custom Field,The model of a host device.
+custom,TRUE,host,host.os.installation_date,date,Custom Field,,Custom Field,The installation date of a host OS.
+custom,TRUE,host,host.serial,keyword,Custom Field,,Custom Field,The serial number associated with a host.
+custom,TRUE,host,host.timezone,keyword,Custom Field,,Custom Field,The timezone that a host device is located in.
+custom,TRUE,related,related.mac,keyword,Custom Field,,Custom Field,All MAC addresses seen on your event.
+custom,TRUE,observer,observer.ingress.interface.host_count,integer,Custom Field,,Custom Field,
+custom,TRUE,event,event.recommendation,keyword,Custom Field,,Custom Field,"Recommendation provided by the log, given an event."
+custom,TRUE,network,network.geo.city_name,keyword,core,,Montreal,City name.
+custom,TRUE,network,network.geo.continent_code,keyword,core,,NA,Continent code.
+custom,TRUE,network,network.geo.continent_name,keyword,core,,North America,Name of the continent.
+custom,TRUE,network,network.geo.country_iso_code,keyword,core,,CA,Country ISO code.
+custom,TRUE,network,network.geo.country_name,keyword,core,,Canada,Country name.
+custom,TRUE,network,network.geo.location,geo_point,core,,"{ ""lon"": -73.614830, ""lat"": 45.505918 }",Longitude and latitude.
+custom,TRUE,network,network.geo.name,keyword,extended,,boston-dc,User-defined description of a location.
+custom,TRUE,network,network.geo.postal_code,keyword,core,,94040,Postal code.
+custom,TRUE,network,network.geo.region_iso_code,keyword,core,,CA-QC,Region ISO code.
+custom,TRUE,network,network.geo.region_name,keyword,core,,Quebec,Region name.
+custom,TRUE,network,network.geo.timezone,keyword,core,,America/Argentina/Buenos_Aires,Time zone.
+custom,TRUE,network,network.geo.street_address,keyword,extended,,,
+custom,TRUE,network,network.geo.site_id,keyword,extended,,,
+custom,TRUE,network,network.description,keyword,extended,,,
+custom,TRUE,network,network.geo.bu,keyword,extended,,,
+custom,TRUE,network,network.network_range,ip_range,extended,,,
+custom,TRUE,network,network.dmz,boolean,extended,,,
+custom,TRUE,network,network.plant_system_control,boolean,extended,,,


### PR DESCRIPTION
## Description
Please provide a description of your proposed changes - providing obfuscated log/code examples is highly encouraged.
We are upgrading to  ECS 1.11 and have added in the following custom fields:
database.user.full_name.text
database.user.name.text
log.source.ip
threat.list.start
threat.list.created
threat.list.injested
threat.list.safe_to_enable_ids
event.modified
host.os.installation_date
observer.ingress.interface.host_count
network.geo.city_name
network.geo.continent_code
network.geo.continent_name
network.geo.country_iso_code
network.geo.country_name
network.geo.location
network.geo.name
network.geo.postal_code
network.geo.region_iso_code
network.geo.region_name
network.geo.timezone
network.geo.street_address
network.geo.site_id
network.description
network.geo.bu
network.network_range
network.dmz
network.plant_system_control


## Related Issues
Are there any Issues to this PR? 
No, push, whenever you're making a change to redeploy logstash.

## Todos
Are there any additional items that must be completed before this PR gets merged in?
- [ ] 
- [ ] 