### PR TITLE
Add general json creation

### DIFF
--- a/build_scripts/generate_settings.py
+++ b/build_scripts/generate_settings.py
@@ -12,6 +12,7 @@ settings_file_path = os.path.join(
 processor_dir = os.path.join(logstash_dir, 'config', 'processors')
 kafka_input_dir = os.path.join(logstash_dir, 'config', 'inputs', 'kafka')
 
+# creating a settings file that has definitions for all processing configs
 processors = []
 for root, _, files in os.walk(processor_dir):
     for file in files:
@@ -33,3 +34,18 @@ for processor in processors:
 
 with open(settings_file_path, 'w') as settings_file:
     json.dump(settings, settings_file, indent=2)
+
+# Creating a general settings file that tells to generate pipelines that should run on single node
+general_settings_file_path = os.path.join(
+    logstash_dir, 'build_scripts', 'general.json')
+
+test_general_json = {
+    "num_indexers" : 1,
+    "prod_only_logs": [
+    ],
+    "processing_config" : {
+    }
+}
+
+with open(general_settings_file_path, 'w') as general_settings_file:
+    json.dump(test_general_json, general_settings_file, indent=2)


### PR DESCRIPTION
## Description
Add general json creation with single node for testing as sample file is an example and has num of nodes 4 defined. So test pipeline does not get to see all configs as only 1/4th pipelines are created.


## Related Issues
Are there any Issues to this PR? 


## Todos
Are there any additional items that must be completed before this PR gets merged in?
- [ ] 
- [ ] 