### PR TITLE
add back mutate copy sections to map MISP fields to ECS

### DIFF
--- a/config/processors/api_log_security_misp.metrics.conf
+++ b/config/processors/api_log_security_misp.metrics.conf
@@ -274,6 +274,262 @@ filter {
   mutate {
     remove_field => [ "misp", "threat.list.event_tag2" ]
   }
+  if [threat.list.type] == "hassh-md5" {
+    mutate {
+      copy => { "threat.list.ioc" => "process.hash.md5" }
+    }
+  }
+  if [threat.list.type] == "hasshserver-md5" {
+    mutate {
+      copy => { "threat.list.ioc" => "process.parent.hash.md5" }
+    }
+  }
+  if [threat.list.type] == "md5" or [threat.list.type] == "ssdeep" or [threat.list.type] == "imphash" or [threat.list.type] == "pehash" or [threat.list.type] == "impfuzzy" or [threat.list.type] == "tlsh" or [threat.list.type] == "cdhash" {
+    mutate {
+      copy => { "threat.list.ioc" => "file.hash.md5" }
+    }
+  }
+  if [threat.list.type] == "sha1" {
+    mutate {
+      copy => { "threat.list.ioc" => "file.hash.sha1" }
+    }
+  }
+  if [threat.list.type] == "sha256" or [threat.list.type] == "authentihash" or [threat.list.type] == "sha224" {
+    mutate {
+      copy => { "threat.list.ioc" => "file.hash.sha256" }
+    }
+  }
+  if [threat.list.type] == "sha512" or [threat.list.type] == "sha384" or [threat.list.type] == "sha512/224" or [threat.list.type] == "sha512/256"{
+    mutate {
+      copy => { "threat.list.ioc" => "file.hash.sha512" }
+    }
+  }
+  if [threat.list.type] == "filename" {
+    mutate {
+      copy => { "threat.list.ioc" => "file.name" }
+    }
+  }
+  if [threat.list.type] == "filename|md5" {
+    dissect {
+      mapping => {
+        "threat.list.ioc" => "%{file.name}|%{file.hash.md5}"
+      }
+    }
+  }
+  if [threat.list.type] == "filename|sha1" {
+    dissect {
+      mapping => {
+        "threat.list.ioc" => "%{file.name}|%{file.hash.sha1}"
+      }
+    }
+  }
+  if [threat.list.type] == "filename|sha256" or [threat.list.type] == "filename|authentihash" or [threat.list.type] == "filename|ssdeep" or [threat.list.type] == "filename|imphash" or [threat.list.type] == "filename|impfuzzy" or [threat.list.type] == "filename|pehash" or [threat.list.type] == "filename|tlsh" or [threat.list.type] == "filename|sha224" {
+    dissect {
+      mapping => {
+        "threat.list.ioc" => "%{file.name}|%{file.hash.sha256}"
+      }
+    }
+  }
+  if [threat.list.type] == "filename|sha384" or [threat.list.type] == "filename|sha512" or [threat.list.type] == "filename|sha512/224" or [threat.list.type] == "filename|sha512/256" {
+    dissect {
+      mapping => {
+        "threat.list.ioc" => "%{file.name}|%{file.hash.sha512}"
+      }
+    }
+  }
+  if [threat.list.type] == "ip-src" {
+    mutate {
+      copy => { "threat.list.ioc" => "source.ip" }
+    }
+  }
+  if [threat.list.type] == "ip-dst" {
+    mutate {
+      copy => { "threat.list.ioc" => "destination.ip" }
+    }
+  }
+  if [threat.list.type] == "hostname" {
+    mutate {
+      copy => { "threat.list.ioc" => "host.hostname" }
+    }
+  }
+  if [threat.list.type] == "domain" {
+    mutate {
+      copy => { "threat.list.ioc" => "url.domain" }
+    }
+  }
+  if [threat.list.type] == "domain|ip" {
+    dissect {
+      mapping => {
+        "threat.list.ioc" => "%{url.domain}|%{destination.ip}"
+      }
+    }
+  }
+  if [threat.list.type] == "url" or [threat.list.type] == "uri" or [threat.list.type] == "btc" or [threat.list.type] == "dash" or [threat.list.type] == "xmr"{
+    mutate {
+      copy => { "threat.list.ioc" => "url.full" }
+    }
+  }
+  if [threat.list.type] == "http-method" {
+    mutate {
+      copy => { "threat.list.ioc" => "http.request.method" }
+    }
+  }
+  if [threat.list.type] == "user-agent" {
+    mutate {
+      copy => { "threat.list.ioc" => "user_agent.original" }
+    }
+  }
+  if [threat.list.type] == "ja3-fingerprint-md5" {
+    mutate {
+      copy => { "threat.list.ioc" => "tls.server.hash.md5" }
+    }
+  }
+  if [threat.list.type] == "regkey" {
+    mutate {
+      copy => { "threat.list.ioc" => "registry.key" }
+    }
+  }
+  if [threat.list.type] == "regkey|value" {
+    dissect {
+      mapping => {
+        "threat.list.ioc" => "%{registry.key}|%{registry.value}"
+      }
+    }
+  }
+  if [threat.list.type] == "AS" {
+    mutate {
+      copy => { "threat.list.ioc" => "source.as.organization.name" }
+    }
+  }
+  if [threat.list.type] == "snort" or [threat.list.type] == "bro" or [threat.list.type] == "zeek" or [threat.list.type] == "yara" or [threat.list.type] == "pattern-in-file" or [threat.list.type] == "pattern-in-traffic" or [threat.list.type] == "pattern-in-memory" {
+    mutate {
+      copy => { "threat.list.ioc" => "rule.description" }
+    }
+  }
+  if [threat.list.type] == "community-id" {
+    mutate {
+      copy => { "threat.list.ioc" => "process.hash.md5" }
+    }
+  }
+  if [threat.list.type] == "mime-type" {
+    mutate {
+      copy => { "threat.list.ioc" => "file.mime_type" }
+    }
+  }
+  if [threat.list.type] == "identity-card-number" {
+    mutate {
+      copy => { "threat.list.ioc" => "user.id" }
+    }
+  }
+  if [threat.list.type] == "cookie" {
+    mutate {
+      copy => { "threat.list.ioc" => "http.cookie.name" }
+    }
+  }
+  if [threat.list.type] == "vulnerability" or [threat.list.type] == "weakness" or [threat.list.type] == "link" {
+    mutate {
+      copy => { "threat.list.ioc" => "vulnerability.reference" }
+    }
+  }
+  if [threat.list.type] == "named pipe" or [threat.list.type] == "mutex" {
+    mutate {
+      copy => { "threat.list.ioc" => "file.path" }
+    }
+  }
+  if [threat.list.type] == "target-user" {
+    mutate {
+      copy => { "threat.list.ioc" => "destination.user.name" }
+    }
+  }
+  if [threat.list.type] == "target-email" {
+    mutate {
+      copy => { "threat.list.ioc" => "destination.user.email" }
+    }
+  }
+  if [threat.list.type] == "target-machine" {
+    mutate {
+      copy => { "threat.list.ioc" => "destination.address" }
+    }
+  }
+  if [threat.list.type] == "target-org" or [threat.list.type] == "target-external"{
+    mutate {
+      copy => { "threat.list.ioc" => "destination.as.organization.name" }
+    }
+  }
+  if [threat.list.type] == "windows-scheduled-task" or [threat.list.type] == "windows-service-name" or [threat.list.type] == "windows-service-displayname" {
+    mutate {
+      copy => { "threat.list.ioc" => "process.name" }
+    }
+  }
+  if [threat.list.type] == "x509-fingerprint-sha1" {
+    mutate {
+      copy => { "threat.list.ioc" => "tls.server.hash.sha1" }
+    }
+  }
+  if [threat.list.type] == "x509-fingerprint-md5" {
+    mutate {
+      copy => { "threat.list.ioc" => "tls.server.hash.md5" }
+    }
+  }
+  if [threat.list.type] == "x509-fingerprint-sha256" {
+    mutate {
+      copy => { "threat.list.ioc" => "tls.server.hash.sha256" }
+    }
+  }
+  if [threat.list.type] == "port" {
+    mutate {
+      copy => { "threat.list.ioc" => "destination.port" }
+    }
+  }
+  if [threat.list.type] == "ip-dst|port" {
+    dissect {
+      mapping => {
+        "threat.list.ioc" => "%{destination.ip}|%{destination.port}"
+      }
+    }
+  }
+  if [threat.list.type] == "hostname|port" {
+    dissect {
+      mapping => {
+        "threat.list.ioc" => "%{destination.address}|%{destination.port}"
+      }
+    }
+  }
+  if [threat.list.type] == "mac-address" or [threat.list.type] == "mac-eui-64" {
+    mutate {
+      copy => { "threat.list.ioc" => "source.mac" }
+    }
+  }
+  if [threat.list.type] == "email-src" or [threat.list.type] == "email-src-display-name" or [threat.list.type] == "email-reply-to" or [threat.list.type] == "email-x-mailer" {
+    mutate {
+      copy => { "threat.list.ioc" => "source.user.email" }
+    }
+  }
+  if [threat.list.type] == "email-dst" or [threat.list.type] == "email-dst-display-name" {
+    mutate {
+      copy => { "threat.list.ioc" => "destination.user.email" }
+    }
+  }
+  if [threat.list.type] == "email-subject" {
+    mutate {
+      copy => { "threat.list.ioc" => "email.subject" }
+    }
+  }
+  if [threat.list.type] == "email-attachment" {
+    mutate {
+      copy => { "threat.list.ioc" => "file.name" }
+    }
+  }
+  if [threat.list.type] == "email-body" {
+    mutate {
+      copy => { "threat.list.ioc" => "email.body" }
+    }
+  }
+  if [threat.list.type] == "email-header" {
+    mutate {
+      copy => { "threat.list.ioc" => "email.header" }
+    }
+  }
   # Do not remove this, due to internal need.
   if [host.hostname] and ([host.hostname] != "" or [host.hostname][0] != "" ){
     mutate {


### PR DESCRIPTION
## Description
Please provide a description of your proposed changes - providing obfuscated log/code examples is highly encouraged.
I had removed a code block of MISP without realizing I had removed the ECS mappings that accompanied the stale memcached code.

## Related Issues
Are there any Issues to this PR? 


## Todos
Are there any additional items that must be completed before this PR gets merged in?
- [ ] 
- [ ] 