### PR TITLE
pipeline generation Bugfix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,8 +76,10 @@ jobs:
         logstash-filter-tld
     - name: Generate pipelines
       env:
+        # See README.md for explaination
         DEPLOY_ENV: test
         MY_INDEX: '1'
+        # INSTANCE_COUNT=1 as we want to include all configs in one pipeline so syntax check can be performed
         INSTANCE_COUNT: '1'
         SUB_MY_IP: abc
         ELASTIC_USER: elastic_user

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,6 +78,7 @@ jobs:
       env:
         DEPLOY_ENV: test
         MY_INDEX: '1'
+        INSTANCE_COUNT: '1'
         SUB_MY_IP: abc
         ELASTIC_USER: elastic_user
         ELASTIC_PASSWORD: elastic_pass

--- a/build_scripts/README.md
+++ b/build_scripts/README.md
@@ -301,6 +301,7 @@ The [generate pipeline script](generate_pipeline.py) uses environment variables 
 ```
 DEPLOY_ENV: test/dev/prod
 MY_INDEX: index of this logtash node in the cluster
+INSTANCE_COUNT: number of instances in the cluster
 SUB_MY_IP: some unique value added to plugin ids
 ELASTIC_USER: elastic username
 ELASTIC_PASSWORD: elastic password

--- a/build_scripts/README.md
+++ b/build_scripts/README.md
@@ -63,7 +63,7 @@ Each input pipeline sends logs to its respective processor config pipeline (for 
 
 ## Working
 
-To process logs we need to create pipelines.yml file. We start with defining enrichments and output pipelines(common for all log sources). Then we add input and processor pipelines only for the logs we process. [settings.json](#settingsjson) is the file where we define the log sources we want to process. The file [general.json](#generaljson) provides specs such as how many nodes we need to process a particular log source. With these settings files and numerous environment variables, [generate_pipelines.py](#generate_pipelinespy) script generates a `pipelines.yml` for a specific Logstash node. If you want to process all configs on all Logstash nodes you just need to run the generate script with `num_indexers` set to 1 in `general.json`.
+To process logs we need to create pipelines.yml file. We start with defining enrichments and output pipelines(common for all log sources). Then we add input and processor pipelines only for the logs we process. [settings.json](#settingsjson) is the file where we define the log sources we want to process. The file [general.json](#generaljson) provides specs such as how many nodes we need to process a particular log source. With these settings files and numerous environment variables, [generate_pipelines.py](#generate_pipelinespy) script generates a `pipelines.yml` for a specific Logstash node. If you want to process all configs on all Logstash nodes you just need to run the generate script with `INSTANCE_COUNT` set to 1 in environment variables.
 
 **Note:** We gather all the logs in Kafka through various log collection agents for temporary storage. We process logs from Kafka and Azure Eventhub and output to Elastic. You can tweak these configuration files and the pipeline generation script for your custom use cases, especially if they fall outside of our scope. We do not process all configs on all nodes because we faced performance problems associated with Kafka and Logstash kafka-input plugin.
 
@@ -142,7 +142,6 @@ This adds capability to process a config explicitly on logstash nodes. Logs can 
 
 ```json
 {
-    "num_indexers" : NUMBER OF LOGSTASH NODES IN THE CLUSTER,
     "prod_only_logs": [
         "LIST OF LOGS WHICH WON'T BE ADDED IN PIPELINES IF ENVIRONMENT VARIABLE DEPLOY_ENV=dev (list should be made of log_source values from settings.json)"
     ],

--- a/build_scripts/general.json
+++ b/build_scripts/general.json
@@ -1,5 +1,4 @@
 {
-    "num_indexers" : 4,
     "prod_only_logs": [
         "event_hub_log_audit_azure.event_hub_audit",
         "event_hub_log_audit_azure.event_hub_signin",

--- a/build_scripts/generate_pipeline.py
+++ b/build_scripts/generate_pipeline.py
@@ -61,16 +61,15 @@ class LogstashHelper(object):
         self.logstash_api_secrets = self.__get_logstash_api_secret()
         self.bucket_name = os.environ['S3_BUCKET_NAME']
         self.prod_only_logs = self.__get_prod_only_logs()
-        self.num_indexers = self.__get_num_indexers()
+        self.num_instances = self.__get_num_instances()
 
     def __get_logstash_api_secret(self):
         logstash_api_sec = os.environ['LOGSTASH_API_SECRET']
         return jsonise(logstash_api_sec)
 
-    def __get_num_indexers(self):
-        general_settings = load_general_settings(self.logstash_dir)
-        indexers = general_settings['num_indexers']
-        return indexers
+    def __get_num_instances(self):
+        num_of_logindexers = os.environ['INSTANCE_COUNT']
+        return num_of_logindexers
 
     def __get_prod_only_logs(self):
         general_settings = load_general_settings(self.logstash_dir)
@@ -284,14 +283,13 @@ class LogstashHelper(object):
             num_servers_for_special_logs += v['nodes']
         
         special_confs = []
-        if self.deploy_env == 'test':
-            num_servers = 1
-        num_servers = general_settings['num_indexers']
+        num_servers = self.num_instances
         # if there are not enough servers for special logs process them like any other
         if num_servers < num_servers_for_special_logs:
-            # cannot process clear lag logs explicitly.
+            # cannot process special logs explicitly.
             # treat them like high volume logs
             self.special_logs = []
+            logger.warning('cannot process special logs explicitly')
             num_servers_for_special_logs = 0
         
         daily_logs = []

--- a/build_scripts/generate_pipeline.py
+++ b/build_scripts/generate_pipeline.py
@@ -68,7 +68,7 @@ class LogstashHelper(object):
         return jsonise(logstash_api_sec)
 
     def __get_num_instances(self):
-        num_of_logindexers = os.environ['INSTANCE_COUNT']
+        num_of_logindexers = int(os.environ['INSTANCE_COUNT'])
         return num_of_logindexers
 
     def __get_prod_only_logs(self):


### PR DESCRIPTION
## Description
Pipeline generation in test was only for 4 instances as the logic was flawed.
In practices, number of instances to process logs is environment specific. e.g. in dev one may only want to test a few logs so only few instances are needed. Hence introduced a new environment variable `INSTANCE_COUNT`. Pass this to generate pipeline for that number of instances. Doc is also updated. Refer https://github.com/Cargill/OpenSIEM-Logstash-Parsing/tree/master/build_scripts#environment-variables


## Related Issues
Are there any Issues to this PR? 


## Todos
Are there any additional items that must be completed before this PR gets merged in?
- [ ] 
- [ ] 