### PR TITLE
removed pri filtering from syslog unidentified

### DIFF
--- a/config/processors/syslog_log_source_unidentified.conf
+++ b/config/processors/syslog_log_source_unidentified.conf
@@ -15,11 +15,7 @@ filter {
   }
   grok {
     tag_on_failure => "_parsefailure_header"
-    match => { "message" => "(^(.*?)(<(?<pri>\d+)>)(\s)?(?<actual_msg>.*$))|(^(?<actual_msg>.*)$)" }
-  }
-  syslog_pri {
-    syslog_pri_field_name => "pri" 
-    remove_field => [ "pri" ]
+    match => { "message" => "(^(.*?)(<\d+)>)(\s)?(?<actual_msg>.*$))|(^(?<actual_msg>.*)$)" }
   }
   mutate {
     remove_field => [ "actual_msg" ]


### PR DESCRIPTION
## Description
Unidentified log sources should not be parsed in any way


## Related Issues
None


## Todos
 None