### PR TITLE
native vlan mismatch and other improvements

### DIFF
--- a/config/processors/syslog_log_audit_cisco.switch.conf
+++ b/config/processors/syslog_log_audit_cisco.switch.conf
@@ -46,7 +46,7 @@ filter {
   }
   mutate {
     id => "cisco-mutate-logoriginal2"
-    lowercase => ["[message]"]
+    lowercase => ["[message]", "[actual_msg]"]
   }
 
   # 2. General cisco log format is 
@@ -56,7 +56,7 @@ filter {
   dissect {
     id => "cisco.router-mutate-dissect-actual_msg"
     mapping => {
-      "actual_msg" => "%{event.id}: %{[tmp][device_timestamp]->} %{+[tmp][device_timestamp]} %{+[tmp][device_timestamp]} %{source.address}: %%{[tmp][facility]}-%{[tmp][severity]}-%{[tmp][mnemonic]}: %{[tmp][msg]}"
+      "actual_msg" => "%{event.id}: %{[tmp][device_timestamp]} %{+[tmp][device_timestamp]} %{+[tmp][device_timestamp]} %{+[tmp][device_timestamp]}: %%{[tmp][facility]}-%{[tmp][severity]}-%{[tmp][mnemonic]}: %{[tmp][msg]}"
     }
   }
 
@@ -223,6 +223,26 @@ filter {
       fallback => "unknown"
       destination => "event.outcome"
     }
+  }
+
+  # 7.4. Native VLAN mismatch
+  if [event.action] == "cdp.native_vlan_mismatch" {
+    grok {
+      id => "cicsco.router-cdp.nativevlan"
+      match => {
+        "[tmp][msg]" => ".* on %{NOTSPACE:[tmp][error_if]}.*, with %{NOTSPACE:[tmp][error_neighbor]} %{NOTSPACE:[tmp][error_neighbor_if]}"
+      }
+    }
+    mutate {
+      add_field => { "event.type" => "connection"}
+      add_field => { "event.category" => "network"}
+      add_field => { "event.kind" => "alert"}
+      split => { "[tmp][error_neighbor]" => "." } # we want to pick only the hostname, not the FQDN
+      add_field => { "related.hosts" => "%{[tmp][error_neighbor][0]}"}
+      add_field => { "observer.ingress.interface.name" => "%{[tmp][error_if]}"}
+      # for the lack of an appropriate ECS field we're not adding [tmp][error_neighbor_if] and it will later be dropped
+    }
+
   }
 
   # 8. Cleanup related IP
@@ -395,13 +415,6 @@ filter {
         }
       }
     }
-    else if [rest_msg] =~ "Native VLAN mismatch" {
-      dissect {
-        mapping => {
-          rest_msg => "%{event.start->} %{+event.start} %{+event.start}: %%{rule.name}: %{rule.description} on %{observer.ingress.interface.name} %{?data}, %{?data} %{source.address} %{destination.interface} %{?data}"
-        }
-      }
-    }
     else if [rest_msg] =~ "queue full" {
       dissect {
         mapping => {
@@ -454,13 +467,6 @@ filter {
         }
       }
     }
-    else {
-      dissect {
-        mapping => {
-          actual_msg => "%{event.start->} %{+event.start} %{+event.start} %{source.address} %%{rule.name}: %{?data}"
-        }
-      }
-    }
   }
   if [event.start] {
     if [event.start] =~ ": " {
@@ -484,14 +490,15 @@ filter {
     field => "[syslog_severity]"
     destination => "[rule.category]"
     dictionary => {
-      "error" => "Security/Failed Activity"
-      "info" => "Security/Activity"
-      "notice" => "Security/Activity"
-      "warning" => "Security/Warning"
+      "error" => "security/failed activity"
+      "info" => "security/activity"
+      "notice" => "security/activity"
+      "warning" => "security/warning"
     }
-      fallback => "Others"
+      fallback => "others"
   }
 }
+
 output {
   pipeline { send_to => [enrichments] }
 }


### PR DESCRIPTION
## Description

- Parsing for Native VLAN mismatch error messages
`2021-10-14T13:28:06.497Z {name=abc.com} <188>132685: Oct 14 21:28:07.975 GMT: %CDP-4-NATIVE_VLAN_MISMATCH: Native VLAN mismatch discovered on FastEthernet0/1 (1), with xyz GigabitEthernet1/0/1 (36).`
- Lowercase [actual_msg] field
- fix typo on timestamp
- add the timezone to [tmp][devicetimestamp]
- removed the old parser code for native vlan mismatch
- removed a [catch all condition in the old parser](https://github.com/Cargill/OpenSIEM-Logstash-Parsing/pull/145/files#diff-24eec3c61283bb6dbc3f0b2c32cc4f8f7f7bddf6f7bbe06f91481346241004a4L457)
- lowercase [rule.category]
