### PR TITLE
Add support for nested fields so all fields are removed if empty and truncated as required

### DIFF
--- a/config/enrichments/02_remove_empty_n_truncate.conf
+++ b/config/enrichments/02_remove_empty_n_truncate.conf
@@ -1,4 +1,4 @@
-# Copyright [2021] [Cargill, Incorporated.] 
+# Copyright [2021] [Cargill, Incorporated.]
 # SPDX-License-Identifier: Apache-2.0
 # remove empty fields and truncate all fields to 1024 bytes
 filter {
@@ -9,7 +9,6 @@ filter {
   } else {
     ruby {
       code => '
-        hash = event.to_hash
         truncate_exclude_list = [
           "message",
           "client.as.organization.name.text",
@@ -61,8 +60,21 @@ filter {
         ]
         # defining it once
         invalid_value_list = ["-", "null", "nil", "n/a"]
-        hash.each do |k,v|
-          if v == nil
+
+        def walk_hash(parent, path, hash)
+          path << parent if parent
+          hash.each do |key, value|
+            walk_hash(key, path, value) if value.is_a?(Hash)
+            @paths << (path + [key]).map {|p| "[" + p + "]" }.join("")
+          end
+          path.pop
+        end
+
+        @paths = []
+        walk_hash(nil, [], event.to_hash)
+        @paths.each do |k|
+          v = event.get(k)
+          if v.nil? || (v.respond_to?(:empty?) && v.empty?)
             event.remove(k)
           else
             if v.is_a? String


### PR DESCRIPTION
## Description
Added support for fields in nested notation. Code traverses through the nested data structure and creates a full path, then existing logic does the needful.

Tested with input
```
input {
  generator {
    lines => [
    '{
      "event" : { 
        "nested_null": "null", 
        "nested_blank": "", 
        "nested_nil": "nil",
        "nested_na": "n/a",
        "nested_dash": "-",
        "file" : {
          "name" : "test_file_name",
          "path" : "-"
        }
      }, 
      "dot.null": "null", 
      "dot.blank": "",
      "dot.nil": "nil",
      "dot.nil": "n/a",
      "dot.dash": "-",
      "good.dot.notation" : "yes",
      "good.dot.array" : ["howda", "", "whatever"],
      "good" : {
        "nested" : {
          "notation": "yes",
          "array": ["howda", "", "whatever"]
        }
      }
    }'
    ]
    count => 1
    codec => json
  }
}
```
Produces output
```
{
             "@version" => "1",
                "event" => {
        "file" => {
            "name" => "test_file_name"
        }
    },
                 "good" => {
        "nested" => {
            "notation" => "yes",
               "array" => [
                [0] "howda",
                [1] "whatever"
            ]
        }
    },
       "good.dot.array" => [
        [0] "howda",
        [1] "whatever"
    ],
           "@timestamp" => 2021-11-05T15:23:10.344Z,
    "good.dot.notation" => "yes"
}
```

### Ref:

https://www.endpointdev.com/blog/2017/11/logstash-remove-fields-empty-values/


## Related Issues
Are there any Issues to this PR? 


## Todos
Are there any additional items that must be completed before this PR gets merged in?
- [ ] 
- [ ] 