### PR TITLE
mcafee.atd: added if conditional to check ip format for destination.ip field

### DIFF
--- a/config/processors/syslog_log_security_mcafee.atd.conf
+++ b/config/processors/syslog_log_security_mcafee.atd.conf
@@ -74,6 +74,12 @@ filter {
       "[atd][Severity]" => "event.severity_name"
     }
   }
+  if [destination.ip] and [destination.ip] !~ "^(\d+\.\d+\.\d+\.\d+|[0-9a-zA-Z]+:.*?:.*?:.*?:.*?:.*?:.*?:[0-9a-zA-Z]+)$" {
+    mutate {
+      add_tag => [ "invalid destination ip in mcafee.atd" ]
+      replace => [ "destination.ip", "99.99.99.99" ]
+    }
+  }
   if ![event.action] {
 	  if [atd][Summary][SubmitterType] and [atd][Summary][SubmitterType] == "MWG" {
       mutate {


### PR DESCRIPTION
## Description
If the ip format for 'destination.ip' is incorrect, adding 99.99.99.99 (dummy) as its value and a tag -- this will avoid log drops and can find what is the exact value of 'ip' fields in kibana.


## Related Issues
No


## Todos
NA