### PR TITLE
Configurable log volume for assigning pipeline workers

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -74,10 +74,11 @@ input {
   }
 }
 ```
-All the VAR* fields are mandatory and need to be passed from environment variable without VAR_ prefix. e.g. a key `VAR_KAFKA_GROUP_ID` should be passed as 
+VAR* fields need to be passed from environment variable without VAR_ prefix. e.g. a key `VAR_RACK_ID` should be passed as 
 ```sh
-export KAFKA_GROUP_ID=logstash_consumer_group
+export VAR_RACK_ID=kafka_rack1
 ```
+Most of above have some default values. You can overwrite them in replace_vars method in [generate_pipeline](build_scripts/generate_pipeline.py)
 
 ### Steps
 

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -92,7 +92,7 @@ touch /mnt/s3fs_geoip/GeoLitePrivate2-City.mmdb
 ```json
 {
   "a10_proxy": {
-    "log_source": "a10_proxy",
+    "volume": "high",
     "config": "syslog_log_audit_a10.proxy",
     "elastic_index": "a10_proxy_audit_index",
     "ignore_enrichments": ["disable_geoip_enrichment"],

--- a/build_scripts/README.md
+++ b/build_scripts/README.md
@@ -121,7 +121,7 @@ See [quick_reference_enrichment_enable_disable.csv](../doc/enrichments/quick_ref
 ```json
 {
   "UNIQUE LOG SOURCE NAME (if using kafka input, kafka topic name is assigned this value. If using other inputs this should be the input file name.)": {
-    "log_source": "must be same as parent key (UNIQUE LOG SOURCE NAME)",
+    "volume": "high, medium or low. Used to allocate pipeline workers",
     "config": "PROCESSOR CONFIG FILE NAME WITHOUT .conf",
     "elastic_index": "INDEX NAME FOR ELASTIC OUTPUT PLUGIN (date patterns can also be used)",
     "ignore_enrichments": ["THESE ARE TAGS THAT ARE ADDED AND ENRICHMENTS CHECK FOR THEM"],
@@ -147,7 +147,7 @@ This adds capability to process a config explicitly on logstash nodes. Logs can 
         "LIST OF LOGS WHICH WON'T BE ADDED IN PIPELINES IF ENVIRONMENT VARIABLE DEPLOY_ENV=dev (list should be made of log_source values from settings.json)"
     ],
     "processing_config" : {
-        "LOG_SOURCE VALUE FROM SETTINGS.JSON" : {
+        "UNIQUE LOG SOURCE NAME FROM SETTINGS.JSON" : {
             "kafka_partitions" : NUMBER OF KAFKA PARTITIONS FOR THIS PARTICULAR LOG SOURCE(this valuse is used to generate number of workers for the kafka input plugin i.e. kafka_partitions/nodes),
             "nodes" : NUMBER OF NODES ON WHICH THIS LOG SOURCE WOULD BE EXPLICITLY PROCESSED
         },

--- a/build_scripts/generate_pipeline.py
+++ b/build_scripts/generate_pipeline.py
@@ -308,9 +308,15 @@ class LogstashHelper(object):
             if self.deploy_env == 'dev' and config_file in self.prod_only_logs:
                 continue
             log_type = config_file.split('_')[-1]
-            if settings[config_file]['volume'] == 'high':
+            try:
+                log_volume = settings[config_file]['volume']
+            except KeyError:
+                logger.warning(f'could not find volume for {config_file}')
+                log_volume = 'undefined'
+
+            if log_volume == 'high':
                 high_volume_logs.append(config_file)
-            elif settings[config_file]['volume'] == 'medium':
+            elif log_volume == 'medium':
                 medium_volume_logs.append(config_file)
             else:
                 low_volume_logs.append(config_file)
@@ -389,10 +395,15 @@ class LogstashHelper(object):
                 f'/config/processors/{log_source_input_conf}'
             # and config name for id
             processor_pipeline_id = f'proc_{log_source}'
-
-            if settings[log_source]['volume'] == 'high':
+            try:
+                log_volume = settings[log_source]['volume']
+            except KeyError:
+                logger.warning(f'could not find volume for {log_source}')
+                log_volume = 'undefined'
+            
+            if log_volume == 'high':
                 pipeline_workers = 8
-            elif settings[log_source]['volume'] == 'medium':
+            elif log_volume == 'medium':
                 pipeline_workers = 4
             else:
                 pipeline_workers = 2

--- a/build_scripts/generate_settings.py
+++ b/build_scripts/generate_settings.py
@@ -20,8 +20,8 @@ for root, _, files in os.walk(processor_dir):
 
 for processor in processors:
     settings[processor] = {
-        "log_source": processor,
         "config": processor,
+        "volume" : "high",
         "elastic_index": processor,
         "ignore_enrichments": [],
         "output_list": [

--- a/build_scripts/settings.json
+++ b/build_scripts/settings.json
@@ -1,6 +1,6 @@
 {
   "syslog_log_audit_a10.proxy": {
-    "log_source": "syslog_log_audit_a10.proxy",
+    "volume" : "high",
     "config": "syslog_log_audit_a10.proxy",
     "elastic_index": "syslog_log_audit_a10.proxy_%{+xxxx.MM}",
     "ignore_enrichments": [],
@@ -13,7 +13,7 @@
     }
   },
   "syslog_log_audit_a10.traffic_monthly": {
-    "log_source": "syslog_log_audit_a10.traffic_monthly",
+    "volume" : "low",
     "config": "syslog_log_audit_a10.traffic_monthly",
     "elastic_index": "syslog_log_audit_a10.traffic_monthly_%{+xxxx.MM}",
     "ignore_enrichments": [],


### PR DESCRIPTION
## Description

Added a new key volume in settings.json and removed log_source key as that was un-necessary and confusing.
Volume can be assigned as high/medium/low. If volume is not assigned, it is assumed to be low. This makes log source name, index name and config name totally independent of each other. Earlier the generate pipeline script used to derive log volume from log source name which would end with daily/weekly/monthly. Now log source name can be anything.


## Related Issues
Are there any Issues to this PR? 


## Todos
Are there any additional items that must be completed before this PR gets merged in?
- [ ] 
- [ ] 