### PR TITLE
Erin verbeck laneupdate mitre translate

### DIFF
--- a/config/enrichments/93_mitre.conf
+++ b/config/enrichments/93_mitre.conf
@@ -53,7 +53,7 @@ if "disable_lookups" in [tags] or "disable_mitre_lookup_enrichment" in [tags] or
       }
       translate {
         iterate_on => "[threat][technique][id]"
-        field => "[threat][technique][id]"
+        source => "[threat][technique][id]"
         dictionary_path => "${LOGSTASH_HOME}/config/mitre_technique.json"
         destination => "[threat][technique][tmp]"
         override => "true"


### PR DESCRIPTION
## Description
Please provide a description of your proposed changes - providing obfuscated log/code examples is highly encouraged.
https://www.elastic.co/guide/en/logstash/current/plugins-filters-translate.html#plugins-filters-translate-iterate_on

According to the translate documentation, if an array of strings is specified in a field, then both the iterate_on field AND the field source need to be added in the translate block:

When the value that you need to perform enrichment on is a variable sized array then specify the field name in this setting. This setting introduces two modes, **_1) when the value is an array of strings_** and 2) when the value is an array of objects (as in JSON object).
**_In the first mode, you should have the same field name in both source and iterate_on, the result will be an array added to the field specified in the target setting. This array will have the looked up value (or the fallback value or nil) in same ordinal position as each sought value._**
In the second mode, specify the field that has the array of objects in iterate_on then specify the field in each object that provides the sought value with source and the field to write the looked up value (or the fallback value) to with target.


Currently, this enrichment is failing when the threat.technique.id is coming in as an array.


## Related Issues
Are there any Issues to this PR? 


## Todos
Are there any additional items that must be completed before this PR gets merged in?
- [ ] 
- [ ] 