### PR TITLE
security tanium:add changes for process.parent.executable and hash.md5 fields

### DIFF
--- a/config/processors/syslog_log_security_tanium.conf
+++ b/config/processors/syslog_log_security_tanium.conf
@@ -12,10 +12,8 @@ filter {
   grok {
     tag_on_failure => "_parsefailure_header"
     match => { "message" => "^(.*? \{.*?} )(?<rest_msg>.*?)$" }
-                 
   }
-
-    json {
+  json {
     source => "rest_msg"
     skip_on_invalid_json => true
     target => "tanm"
@@ -26,11 +24,11 @@ filter {
     copy => { "[tanm][Intel Type]" => "[event][dataset]" }
     rename => {"[tanm][Alert Id]" => "[event][id]" }
     rename => {"[tanm][Computer Name]" => "[host][hostname]" }
-    rename => {"[tanm][Computer IP]" => "[source][address]" }
+    rename => {"[tanm][Computer IP]" => "[source][ip]" }
     rename => {"[tanm][Intel Id]" => "[event][id]" }
-    rename => {"[tanm][Intel Type]" => "[intel][type]" } ### change
+    # rename => {"[tanm][Intel Type]" => "[intel][type]" } ### change
     rename => {"[tanm][Intel Name]" => "[rule][name]" }
-    rename => {"[tanm][Intel Labels]" => "[intel][label]" } ### change
+    rename => {"[tanm][Intel Labels]" => "[labels]" }
     rename => {"[tanm][MITRE Techniques]" => "[threat][technique][id]" }
     rename => {"[tanm][Match Details][system_info][bits]" => "[host][architecture]" }
     rename => {"[tanm][Match Details][system_info][os]" => "[host][os][name]" }
@@ -53,7 +51,7 @@ filter {
     # rename => {"[tanm][match][Match Details][properties][file][size]" =>  "" }
     rename => {"[tanm][Match Details][match][properties][parent][args]" => "[process][parent][args]" }
     rename => {"[tanm][Match Details][match][properties][parent][user]" => "[user][tmp]" }
-    rename => {"[tanm][Match Details][match][properties][parent][file][name]" => "[process][parent][executable]" }
+    rename => {"[tanm][Match Details][match][properties][parent][file][fullpath]" => "[process][parent][executable]" }
     rename => {"[tanm][Match Details][match][properties][parent][file][md5]" => "[process][parent][hash][md5]" }
     rename => {"[tanm][Match Details][match][properties][parent][file][sha1]" => "[process][parent][hash][sha1]" }
     rename => {"[tanm][Match Details][match][properties][parent][file][sha256]" => "[process][parent][hash][sha256]" }
@@ -84,7 +82,7 @@ filter {
     mutate {
       merge => {"[process][parent][args]" => "[tanm][Match Details][match][properties][parent][parent][args]" }
       rename => {"[tanm][Match Details][match][properties][parent][parent][user]" => "[user][tmp]" }
-      merge => {"[process][parent][executable]" => "[tanm][Match Details][match][properties][parent][parent][file][name]" }
+      merge => {"[process][parent][executable]" => "[tanm][Match Details][match][properties][parent][parent][file][fullpath]" }
       merge => {"[process][parent][hash][md5]" => "[tanm][Match Details][match][properties][parent][parent][parent][file][md5]" }
       merge => {"[process][parent][hash][sha1]" =>  "[tanm][Match Details][match][properties][parent][parent][file][sha1]" }
       merge => {"[process][parent][hash][sha256]" => "[tanm][Match Details][match][properties][parent][parent][file][sha256]" }
@@ -115,7 +113,7 @@ filter {
     mutate {
       merge => {"[process][parent][args]" => "[tanm][Match Details][match][properties][parent][parent][parent][args]" }
       rename => {"[tanm][Match Details][match][properties][parent][parent][parent][user]" => "[user][tmp]" }
-      merge => {"[process][parent][executable]" => "[tanm][Match Details][match][properties][parent][parent][parent][file][nam]" }
+      merge => {"[process][parent][executable]" => "[tanm][Match Details][match][properties][parent][parent][parent][file][fullpath]" }
       merge => {"[process][parent][hash][md5]" => "[tanm][Match Details][match][properties][parent][parent][parent][parent][file][md5]" }
       merge => {"[process][parent][hash][sha1]" =>  "[tanm][Match Details][match][properties][parent][parent][parent][file][sha1]" }
       merge=> {"[process][parent][hash][sha256]" => "[tanm][Match Details][match][properties][parent][parent][parent][file][sha256]" }
@@ -145,7 +143,7 @@ filter {
     mutate {
       merge => {"[process][parent][args]" => "[tanm][Match Details][match][properties][parent][parent][parent][parent][args]" }
       rename => {"[tanm][Match Details][match][properties][parent][parent][parent][parent][user]"  => "[user][tmp]" }
-      merge => {"[process][parent][executable]" => "[tanm][Match Details][match][properties][parent][parent][parent][parent][file][name]" }
+      merge => {"[process][parent][executable]" => "[tanm][Match Details][match][properties][parent][parent][parent][parent][file][fullpath]" }
       merge => {"[process][parent][hash][md5]" => "[tanm][Match Details][match][properties][parent][parent][parent][parent][parent][file][md5]" }
       merge => {"[process][parent][hash][sha1]" =>  "[tanm][Match Details][match][properties][parent][parent][parent][parent][file][sha1]" }
       merge=> {"[process][parent][hash][sha256]" => "[tanm][Match Details][match][properties][parent][parent][parent][parent][file][sha256]" }
@@ -175,7 +173,7 @@ filter {
     mutate {
       merge => {"[process][parent][args]" => "[tanm][Match Details][match][properties][parent][parent][parent][parent][parent][args]" }
       rename => {"[tanm][Match Details][match][properties][parent][parent][parent][parent][parent][user]"  => "[user][tmp]" }
-      merge => {"[process][parent][executable]" => "[tanm][Match Details][match][properties][parent][parent][parent][parent][parent][file][name]" }
+      merge => {"[process][parent][executable]" => "[tanm][Match Details][match][properties][parent][parent][parent][parent][parent][file][fullpath]" }
       merge => {"[process][parent][hash][md5]" => "[tanm][Match Details][match][properties][parent][parent][parent][parent][parent][parent][file][md5]" }
       merge => {"[process][parent][hash][sha1]" =>  "[tanm][Match Details][match][properties][parent][parent][parent][parent][parent][file][sha1]" }
       merge=> {"[process][parent][hash][sha256]" => "[tanm][Match Details][match][properties][parent][parent][parent][parent][parent][file][sha256]" }
@@ -205,7 +203,7 @@ filter {
     mutate {
       merge => {"[process][parent][args]" => "[tanm][Match Details][match][properties][parent][parent][parent][parent][parent][parent][args]" }
       rename => {"[tanm][Match Details][match][properties][parent][parent][parent][parent][parent][parent][user]" => "[user][tmp]" }
-      merge => {"[process][parent][executable]" => "[tanm][Match Details][match][properties][parent][parent][parent][parent][parent][parent][file][name]" }
+      merge => {"[process][parent][executable]" => "[tanm][Match Details][match][properties][parent][parent][parent][parent][parent][parent][file][fullpath]" }
       merge => {"[process][parent][hash][md5]" => "[tanm][Match Details][match][properties][parent][parent][parent][parent][parent][parent][parent][file][md5]" }
       merge => {"[process][parent][hash][sha1]" =>  "[tanm][Match Details][match][properties][parent][parent][parent][parent][parent][parent][file][sha1]" }
       merge=> {"[process][parent][hash][sha256]" => "[tanm][Match Details][match][properties][parent][parent][parent][parent][parent][parent][file][sha256]" }


### PR DESCRIPTION
## Description
- taking process.parent.executable from [file][fullpath] instead of [file][name]
- [source][address] renamed to [source][ip]
- field "[intel][type]" commented as it is already been added to "[event][dataset]"
- field "[intel][label]" renamed to "[labels]"


## Related Issues
No


## Todos
NA