### PR TITLE
reverting field name from [labels] to its original

### DIFF
--- a/config/processors/syslog_log_security_tanium.conf
+++ b/config/processors/syslog_log_security_tanium.conf
@@ -28,7 +28,7 @@ filter {
     rename => {"[tanm][Intel Id]" => "[event][id]" }
     # rename => {"[tanm][Intel Type]" => "[intel][type]" } ### change
     rename => {"[tanm][Intel Name]" => "[rule][name]" }
-    rename => {"[tanm][Intel Labels]" => "[labels]" }
+    rename => {"[tanm][Intel Labels]" => "[intel][label]" }
     rename => {"[tanm][MITRE Techniques]" => "[threat][technique][id]" }
     rename => {"[tanm][Match Details][system_info][bits]" => "[host][architecture]" }
     rename => {"[tanm][Match Details][system_info][os]" => "[host][os][name]" }


### PR DESCRIPTION
## Description
labels field is expecting a dictionary but receiving array instead. So, logs are dropped. To avoid that, temporarily, the field is being reverted back to its original name.


## Related Issues
No


## Todos
NA