### PR TITLE
translate filter plugin - use source, target instead of field, destination

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Set logstash variables to be used accross steps
       run: |
-        export LOGSTASH_VERSION=7.12.0
+        export LOGSTASH_VERSION=7.16.2
         export LOGSTASH_HOME="/usr/share/logstash"
         echo "LOGSTASH_VERSION=$LOGSTASH_VERSION" >> $GITHUB_ENV
         echo "LOGSTASH_HOME=$LOGSTASH_HOME" >> $GITHUB_ENV

--- a/config/enrichments/90_lookup_iana_protocol.conf
+++ b/config/enrichments/90_lookup_iana_protocol.conf
@@ -8,9 +8,9 @@ filter {
   } else {
     if ![network][protocol] and [destination][port] { 
       translate {
-        field => "[destination][port]"
+        source => "[destination][port]"
         dictionary_path => "${LOGSTASH_HOME}/config/iana_protocols.csv"
-        destination => "[network][protocol]"
+        target => "[network][protocol]"
         override => "true"
         # Disable refresh from disk because when we update the dictionary file, we restart logstash explicitly
         refresh_interval => 0
@@ -18,9 +18,9 @@ filter {
     }
     if ![network][protocol] and [server][port] { 
       translate {
-        field => "[server][port]"
+        source => "[server][port]"
         dictionary_path => "${LOGSTASH_HOME}/config/iana_protocols.csv"
-        destination => "[network][protocol]"
+        target => "[network][protocol]"
         override => "true"
         # Disable refresh from disk as when we update the dictionary file, we restart logstash explicitly
         refresh_interval => 0
@@ -28,9 +28,9 @@ filter {
     }
     if ![network][protocol] and [url][port] { 
       translate {
-        field => "[url][port]"
+        source => "[url][port]"
         dictionary_path => "${LOGSTASH_HOME}/config/iana_protocols.csv"
-        destination => "[network][protocol]"
+        target => "[network][protocol]"
         override => "true"
         # Disable refresh from disk as when we update the dictionary file, we restart logstash explicitly
         refresh_interval => 0

--- a/config/enrichments/93_mitre.conf
+++ b/config/enrichments/93_mitre.conf
@@ -20,9 +20,9 @@ if "disable_lookups" in [tags] or "disable_mitre_lookup_enrichment" in [tags] or
       }
       translate {
         iterate_on => "[threat][tactic][id]"
-        field => "[threat][tactic][id]"
+        source => "[threat][tactic][id]"
         dictionary_path => "${LOGSTASH_HOME}/config/mitre_tactics.json"
-        destination => "[threat][tactic][tmp]"
+        target => "[threat][tactic][tmp]"
         override => "true"
         # Disable refresh from disk because when we update the dictionary file, we restart logstash explicitly
         refresh_interval => 0
@@ -53,9 +53,9 @@ if "disable_lookups" in [tags] or "disable_mitre_lookup_enrichment" in [tags] or
       }
       translate {
         iterate_on => "[threat][technique][id]"
-        field => "[threat][technique][id]"
+        source => "[threat][technique][id]"
         dictionary_path => "${LOGSTASH_HOME}/config/mitre_technique.json"
-        destination => "[threat][technique][tmp]"
+        target => "[threat][technique][tmp]"
         override => "true"
         # Disable refresh from disk because when we update the dictionary file, we restart logstash explicitly
         refresh_interval => 0
@@ -86,9 +86,9 @@ if "disable_lookups" in [tags] or "disable_mitre_lookup_enrichment" in [tags] or
       }
       translate {
         iterate_on => "[threat][technique][subtechnique][id]"
-        field => "[threat][technique][subtechnique][id]"
+        source => "[threat][technique][subtechnique][id]"
         dictionary_path => "${LOGSTASH_HOME}/config/mitre_subtechnique.json"
-        destination => "[threat][technique][subtechnique][tmp]"
+        target => "[threat][technique][subtechnique][tmp]"
         override => "true"
         # Disable refresh from disk because when we update the dictionary file, we restart logstash explicitly
         refresh_interval => 0

--- a/config/processors/api_log_audit_aws.cloudtrail.conf
+++ b/config/processors/api_log_audit_aws.cloudtrail.conf
@@ -82,8 +82,8 @@ filter {
     }
   }
   translate {
-    field => "[event][category]"
-    destination => "[event][category]"
+    source => "[event][category]"
+    target => "[event][category]"
     dictionary => {
       "management" => "configuration"
       "Data" => "database"

--- a/config/processors/api_log_security_misp.metrics.conf
+++ b/config/processors/api_log_security_misp.metrics.conf
@@ -90,8 +90,8 @@ filter {
   ##### TODO: "event_analysis",  2,  [0,1,2,3] need translation "event_analysis" to [threat][list][event_analysis]
   ### lookups
   translate {
-    field => "[misp][event_distribution]"
-    destination => "[threat][list][distribution]"
+    source => "[misp][event_distribution]"
+    target => "[threat][list][distribution]"
     dictionary => {
       "0" => "Your organisation only"
       "1" => "This community only"

--- a/config/processors/flat_file_log_audit_pingfederate.conf
+++ b/config/processors/flat_file_log_audit_pingfederate.conf
@@ -91,8 +91,8 @@ filter {
   ## 188 - Warning
   ## 191 - debug
   translate {
-    field => "[log][level]"
-    destination => "[rule][category]"
+    source => "[log][level]"
+    target => "[rule][category]"
     dictionary => {
       "187" => "Ops Error"
       "188" => "Ops Warning"

--- a/config/processors/syslog_log_audit_cisco.aci.conf
+++ b/config/processors/syslog_log_audit_cisco.aci.conf
@@ -125,8 +125,8 @@ filter {
   if [event][kind] == "fault"
   {
     translate {
-      field => "[event][action]"
-      destination => "[event][category]"
+      source => "[event][action]"
+      target => "[event][category]"
       dictionary => {
       "link-state-change" => "host"
       }
@@ -135,8 +135,8 @@ filter {
   else
   {
     translate {
-      field => "[[log][syslog][facility][name]]"
-      destination => "[event][category]"
+      source => "[[log][syslog][facility][name]]"
+      target => "[event][category]"
       dictionary => {
       "LOG_AUTH" => "authentication"
       }

--- a/config/processors/syslog_log_audit_cisco.dna.conf
+++ b/config/processors/syslog_log_audit_cisco.dna.conf
@@ -131,19 +131,19 @@ filter {
   # 3. translate DNA into ECS
   translate {
     id => "cisco.dna-translate-category"
-    field => "[tmp][details][assurance issue category]"
+    source => "[tmp][details][assurance issue category]"
     dictionary => [
     "availability", "network" 
     ]
     exact => true
     # [field]-[error]
     fallback => "host"
-    destination => "[event][category]"
+    target => "[event][category]"
   }
     
   translate {
     id => "cisco.dna-translate-kind"
-    field => "[tmp][details][assurance issue status]"
+    source => "[tmp][details][assurance issue status]"
     dictionary => [
     "resolved", "event",
     "active", "event"
@@ -151,12 +151,12 @@ filter {
     exact => true
     # [field]-[error]
     fallback => "event"
-    destination => "[event][kind]"
+    target => "[event][kind]"
   }
 
   translate {
     id => "cisco.dna-translate-type"
-    field => "[tmp][category]"
+    source => "[tmp][category]"
     dictionary => [
       "warn", "info",
       "task_failure", "error",
@@ -164,7 +164,7 @@ filter {
     ]
     exact => true
     fallback => "info"
-    destination => "[event][type]"
+    target => "[event][type]"
   }
 
   # 4. Specific event/field extraction

--- a/config/processors/syslog_log_audit_cisco.router.conf
+++ b/config/processors/syslog_log_audit_cisco.router.conf
@@ -125,8 +125,8 @@ filter {
   }
   translate {
     id => "cisco-translate-facility"
-    field => "[tmp][facility]"
-    destination => "[tmp][facility_translation]"
+    source => "[tmp][facility]"
+    target => "[tmp][facility_translation]"
     dictionary_path => "${LOGSTASH_HOME}/config/cisco_ios_facility_categories.csv"  # ** Must set full "/path/to/lookup.json" to your lookup file **
     refresh_interval => 3000
     fallback => "not_found_facility"
@@ -135,8 +135,8 @@ filter {
   # b. Translate full msg, explanation, recommendation
   translate {
     id => "cisco-translate-mnemonic"
-    field => "[tmp][mnemonic]"
-    destination => "[tmp][mnemonic_translation]"
+    source => "[tmp][mnemonic]"
+    target => "[tmp][mnemonic_translation]"
     dictionary_path => "${LOGSTASH_HOME}/config/cisco_ios.json" # ** Must set full "/path/to/lookup.json" to your lookup file **
     refresh_interval => 3000
     fallback => '{"key1":"not_found"}'
@@ -184,14 +184,14 @@ filter {
     }
 
     translate {
-      field => "[tmp][bgp][state]"
+      source => "[tmp][bgp][state]"
       dictionary => [
       "down", "failure", 
       "up", "success"
       ]
       exact => true
       fallback => "unknown"
-      destination => "[event][outcome]"
+      target => "[event][outcome]"
     }
   }
 
@@ -214,7 +214,7 @@ filter {
     }
 
     translate {
-      field => "[tmp][interface][state]"
+      source => "[tmp][interface][state]"
       dictionary => [
       "down", "failure", 
       "up", "success"
@@ -222,7 +222,7 @@ filter {
       exact => true
       # [field]-[error]
       fallback => "unknown"
-      destination => "[event][outcome]"
+      target => "[event][outcome]"
     }
   }
 
@@ -245,7 +245,7 @@ filter {
     }
 
     translate {
-      field => "[tmp][interface][state]"
+      source => "[tmp][interface][state]"
       dictionary => [
       "down", "failure", 
       "up", "success"
@@ -253,7 +253,7 @@ filter {
       exact => true
       # [field]-[error]
       fallback => "unknown"
-      destination => "[event][outcome]"
+      target => "[event][outcome]"
     }
   }
 

--- a/config/processors/syslog_log_audit_cisco.switch.conf
+++ b/config/processors/syslog_log_audit_cisco.switch.conf
@@ -96,8 +96,8 @@ filter {
   # a. perform facility translation
   translate {
       id => "cisco-translate-facility"
-      field => "[tmp][facility]"
-      destination => "[tmp][facility_translation]"
+      source => "[tmp][facility]"
+      target => "[tmp][facility_translation]"
       dictionary_path => "${LOGSTASH_HOME}/config/cisco_ios_facility_categories.csv"  # ** Must set full "/path/to/lookup.json" to your lookup file **
       refresh_interval => 3000
       fallback => "not_found_facility"
@@ -106,8 +106,8 @@ filter {
   # b. Translate full msg, explanation, recommendation
   translate {
     id => "cisco-translate-mnemonic"
-    field => "[tmp][mnemonic]"
-    destination => "[tmp][mnemonic_translation]"
+    source => "[tmp][mnemonic]"
+    target => "[tmp][mnemonic_translation]"
     dictionary_path => "${LOGSTASH_HOME}/config/cisco_ios.json" # ** Must set full "/path/to/lookup.json" to your lookup file **
     refresh_interval => 3000
     fallback => '{"key1":"not_found"}' 
@@ -155,14 +155,14 @@ filter {
     }
 
     translate {
-      field => "[tmp][bgp][state]"
+      source => "[tmp][bgp][state]"
       dictionary => [
       "down", "failure", 
       "up", "success"
       ]
       exact => true
       fallback => "unknown"
-      destination => "[event][outcome]"
+      target => "[event][outcome]"
     }
   }
 
@@ -185,7 +185,7 @@ filter {
     }
 
     translate {
-      field => "[tmp][interface][state]"
+      source => "[tmp][interface][state]"
       dictionary => [
       "down", "failure", 
       "up", "success"
@@ -193,7 +193,7 @@ filter {
       exact => true
       # [field]-[error]
       fallback => "unknown"
-      destination => "[event][outcome]"
+      target => "[event][outcome]"
     }
   }
 
@@ -216,7 +216,7 @@ filter {
     }
 
     translate {
-      field => "[tmp][interface][state]"
+      source => "[tmp][interface][state]"
       dictionary => [
       "down", "failure", 
       "up", "success"
@@ -224,7 +224,7 @@ filter {
       exact => true
       # [field]-[error]
       fallback => "unknown"
-      destination => "[event][outcome]"
+      target => "[event][outcome]"
     }
   }
   # 7.4. Native VLAN mismatch
@@ -487,8 +487,8 @@ filter {
     remove_field => [ "actual_msg", "rest_msg", "[log][date]", "[destination][interface]", "[network][vlan][id]" ]
   }
   translate {
-    field => "[syslog_severity]"
-    destination => "[rule][category]"
+    source => "[syslog_severity]"
+    target => "[rule][category]"
     dictionary => {
       "error" => "security/failed activity"
       "info" => "security/activity"

--- a/config/processors/syslog_log_audit_citrix.netscaler.conf
+++ b/config/processors/syslog_log_audit_citrix.netscaler.conf
@@ -256,8 +256,8 @@ filter {
       }
     }
     translate {
-      field => "[classification_values]"
-      destination => "[event][category]"
+      source => "[classification_values]"
+      target => "[event][category]"
       dictionary => {
         "SSL_HANDSHAKE_SUCCESS" => "Audit/Information"
         "SSL_HANDSHAKE_SUBJECTNAME" => "Audit/Information"

--- a/config/processors/syslog_log_audit_f5.big.ip.gtm.dns.conf
+++ b/config/processors/syslog_log_audit_f5.big.ip.gtm.dns.conf
@@ -173,8 +173,8 @@ filter {
     remove_field => ["actual_msg","[log][date]", "auth_failure"]
   }
   translate {
-    field => "[[event][severity_name]]"
-    destination => "[rule][category]"
+    source => "[[event][severity_name]]"
+    target => "[rule][category]"
     dictionary => {
       "ERRR" => "Security/Failed Activity"
       "INFO" => "Security/Activity"

--- a/config/processors/syslog_log_audit_f5.big.ip.ltm.conf
+++ b/config/processors/syslog_log_audit_f5.big.ip.ltm.conf
@@ -293,8 +293,8 @@ filter {
     target => "[event][created]"
   }
   translate {
-    field => "[pri]"
-    destination => "[rule][category]"
+    source => "[pri]"
+    target => "[rule][category]"
     dictionary => {
       "ERRR" => "Security/Failed Activity"
       "INFO" => "Security/Activity"

--- a/config/processors/syslog_log_audit_linux.host.conf
+++ b/config/processors/syslog_log_audit_linux.host.conf
@@ -133,8 +133,8 @@ filter {
   }
   #### Classification part ####
   translate {
-    field => "[event][severity_name]"
-    destination => "[rule][category]"
+    source => "[event][severity_name]"
+    target => "[rule][category]"
     dictionary => {
       "ERROR" => "Ops Error"
       "fatal: Access denied" => "Ops Network deny"

--- a/config/processors/syslog_log_audit_riverbed.netim_weekly.conf
+++ b/config/processors/syslog_log_audit_riverbed.netim_weekly.conf
@@ -72,8 +72,8 @@ filter {
     }
     
     translate {
-      field => "[tmp][app_severity]"
-      destination => "[log][syslog][severity][code]"
+      source => "[tmp][app_severity]"
+      target => "[log][syslog][severity][code]"
       dictionary => {
         "critical" => 2
         "major" => 3
@@ -84,8 +84,8 @@ filter {
     }
 
     translate {
-      field => "[log][syslog][severity][code]"
-      destination => "[log][syslog][severity][name]"
+      source => "[log][syslog][severity][code]"
+      target => "[log][syslog][severity][name]"
       dictionary => {
         "0" => "emergency"
         "1" => "alert" 

--- a/config/processors/syslog_log_audit_rsa.auth.conf
+++ b/config/processors/syslog_log_audit_rsa.auth.conf
@@ -34,8 +34,8 @@ filter {
     target => "[event][start]"
   }
   translate {
-    field => "pri"
-    destination => "[rule][category]"
+    source => "pri"
+    target => "[rule][category]"
     dictionary => {
       "ERRR" => "Security/Failed Activity"
       "INFO" => "Security/Activity"

--- a/config/processors/syslog_log_security_bomgar.conf
+++ b/config/processors/syslog_log_security_bomgar.conf
@@ -49,8 +49,8 @@ filter {
     strip => ["[source][ip]"]
   }
   translate {
-    field => "[event][action]"
-    destination => "[rule][category]"
+    source => "[event][action]"
+    target => "[rule][category]"
     dictionary => {
       "logout" => "Audit/Access Revoked"
       "login" => "Audit/Authentication Success"

--- a/config/processors/syslog_log_security_cisco.ise.conf
+++ b/config/processors/syslog_log_security_cisco.ise.conf
@@ -126,8 +126,8 @@ filter {
 
   # 6. Categorizations
   translate {
-    field => "[event][action]"
-    destination => "[event][module]"
+    source => "[event][action]"
+    target => "[event][module]"
     dictionary => {
       "CISE_Passed_Authentications" => "aaa_audit"
       "CISE_AAA_Audit" => "aaa_audit"
@@ -150,8 +150,8 @@ filter {
     fallback => "event"
   }
   translate {
-      field => "[event][action]"
-      destination => "[event][kind]"
+      source => "[event][action]"
+      target => "[event][kind]"
       dictionary => {
           "CISE_Failed_Authentications" => "alert"
           "CISE_Failed_Attempts" => "alert"
@@ -159,8 +159,8 @@ filter {
       fallback => "event"
   }
   translate {
-    field => "[event][action]"
-    destination => "[event][category]"
+    source => "[event][action]"
+    target => "[event][category]"
     dictionary => {
       "CISE_System_Diagnostics" => "host"
       "CISE_Licensing" => "host"
@@ -170,8 +170,8 @@ filter {
     fallback => "authentication"
   }
   translate {
-    field => "[event][action]"
-    destination => "[event][type]"
+    source => "[event][action]"
+    target => "[event][type]"
     dictionary => {
       "CISE_Passed_Authentications" => "allowed"
       "CISE_Failed_Authentications" => "denied"
@@ -181,8 +181,8 @@ filter {
     fallback => "access"
   }
   translate {
-    field => "[event][action]"
-    destination => "[event][outcome]"
+    source => "[event][action]"
+    target => "[event][outcome]"
     dictionary => {
       "CISE_Passed_Authentications" => "success"
       "CISE_Failed_Authentications" => "failure"

--- a/config/processors/syslog_log_security_cisco.meraki.fw.conf
+++ b/config/processors/syslog_log_security_cisco.meraki.fw.conf
@@ -141,8 +141,8 @@ filter {
     remove_field => ["rest_msg", "rest_msg1", "[meraki]", "actual_msg"]
   }
   translate {
-    field => "[syslog_severity]"
-    destination => "[rule][category]"
+    source => "[syslog_severity]"
+    target => "[rule][category]"
     dictionary => {
       "error" => "Security/Vulnerability"
       "info" => "Security/Activity"

--- a/config/processors/syslog_log_security_forescout.counteract.nac.conf
+++ b/config/processors/syslog_log_security_forescout.counteract.nac.conf
@@ -261,8 +261,8 @@ filter {
   }
 
   translate {
-    field => "[[event][severity_name]]"
-    destination => "[rule][category]"
+    source => "[[event][severity_name]]"
+    target => "[rule][category]"
     dictionary => {
       "ERRR" => "Security/Failed Activity"
       "INFO" => "Security/Activity"

--- a/config/processors/syslog_log_security_layer7.securespan.soa.gw.conf
+++ b/config/processors/syslog_log_security_layer7.securespan.soa.gw.conf
@@ -215,8 +215,8 @@ filter {
   }
   #### Classification part ####
   translate {
-    field => "[event][severity_name]"
-    destination => "[rule][category]"
+    source => "[event][severity_name]"
+    target => "[rule][category]"
     dictionary => {
       "WARNING" => "Ops Warning"
       "INFO" => "Ops Information"

--- a/config/processors/syslog_log_security_mcafee.mwg.conf
+++ b/config/processors/syslog_log_security_mcafee.mwg.conf
@@ -111,8 +111,8 @@ filter {
   }
 
   translate {
-    field => "[[rule][id]]"
-    destination => "[rule][description]"
+    source => "[[rule][id]]"
+    target => "[rule][description]"
     dictionary => {
       "0" => "Allowed"
       "1" => "Internal error"

--- a/config/processors/syslog_log_security_microsoft.ata.conf
+++ b/config/processors/syslog_log_security_microsoft.ata.conf
@@ -108,8 +108,8 @@ filter {
   # 2024  Abnormal modification of sensitive groups
   # 2026  Suspicious service creation
   translate {
-    field => "[event][id]"
-    destination => "[rule][category]"
+    source => "[event][id]"
+    target => "[rule][category]"
     dictionary => {
       "2001" => "Security/Suspicious"
       "2002" => "Security/Other"

--- a/config/processors/syslog_log_security_sap.onapsis.conf
+++ b/config/processors/syslog_log_security_sap.onapsis.conf
@@ -98,8 +98,8 @@ filter {
       remove_field => ["[sap]","[log][date_time]","msg","actual_msg"]
     }
     translate {
-    field => "[event][type]"
-    destination => "[rule][category]"
+    source => "[event][type]"
+    target => "[rule][category]"
     dictionary => {
       "UserLogin" => "Audit/Access Success"
       "UserUnlocked" => "Audit/Access Granted"

--- a/config/processors/syslog_log_security_sdwan.app.conf
+++ b/config/processors/syslog_log_security_sdwan.app.conf
@@ -78,8 +78,8 @@ filter {
   # a. event kind (alert, event, metric, state, pipeline_error, signal)
   translate {
     id => "sdwan.app-translate-eventkind"
-    field => "[tmp][dataset]"
-    destination => "[event][kind]"
+    source => "[tmp][dataset]"
+    target => "[event][kind]"
     dictionary => {
     "alarmlog" => "alert"
     "accesslog" => "state"
@@ -131,8 +131,8 @@ filter {
       }
 
       translate {
-        field => "[event][action]"
-        destination => "[event][outcome]"
+        source => "[event][action]"
+        target => "[event][outcome]"
         dictionary => {
           "performancedegradeed" => "failure"
           "outofservice" => "failure"
@@ -181,8 +181,8 @@ filter {
 
       # rfc 5424 translation. see https://datatracker.ietf.org/doc/html/rfc5424#appendix-a.3 on why we do this
       translate {
-        field => "[tmp][rest_msg][alarmseverity]"
-        destination => "[log][syslog][severity][name]"
+        source => "[tmp][rest_msg][alarmseverity]"
+        target => "[log][syslog][severity][name]"
         dictionary => {
           "warning" => "warning"
           "indeterminate" => "informational"
@@ -195,8 +195,8 @@ filter {
       }
 
       translate {
-        field => "[tmp][rest_msg][alarmseverity]"
-        destination => "[log][syslog][severity][code]"
+        source => "[tmp][rest_msg][alarmseverity]"
+        target => "[log][syslog][severity][code]"
         dictionary => {
           "warning" => 4
           "indeterminate" => 6

--- a/config/processors/syslog_log_security_sdwan.os_ubuntu.conf
+++ b/config/processors/syslog_log_security_sdwan.os_ubuntu.conf
@@ -100,8 +100,8 @@ filter {
 
     # rfc 5424 translation. see https://datatracker.ietf.org/doc/html/rfc5424#appendix-a.3 on why we do this
     translate {
-      field => "[tmp][details][severity]"
-      destination => "[log][syslog][severity][name]"
+      source => "[tmp][details][severity]"
+      target => "[log][syslog][severity][name]"
       dictionary => {
         "warning" => "warning"
         "indeterminate" => "informational"
@@ -114,8 +114,8 @@ filter {
     }
 
     translate {
-      field => "[tmp][details][severity]"
-      destination => "[log][syslog][severity][code]"
+      source => "[tmp][details][severity]"
+      target => "[log][syslog][severity][code]"
       dictionary => {
         "warning" => 4
         "indeterminate" => 6

--- a/config/processors/syslog_log_security_tufin.conf
+++ b/config/processors/syslog_log_security_tufin.conf
@@ -85,8 +85,8 @@ filter {
   }
   ### classification Part ############
   translate {
-    field => "[event][severity_name]"
-    destination => "[rule][category]"
+    source => "[event][severity_name]"
+    target => "[rule][category]"
     dictionary => {
       "ERRR" => "Security Failed Activity"
       "INFO" => "Security Activity"

--- a/config/processors/wef_log_audit_windows.events.conf
+++ b/config/processors/wef_log_audit_windows.events.conf
@@ -249,8 +249,8 @@ filter {
       timeout_millis => 500
     }
     translate {
-      field => "failure_code"
-      destination => "[event][reason]"
+      source => "failure_code"
+      target => "[event][reason]"
       dictionary => {
         "0x1" => "Client's entry in database has expired"
         "0x2" => "Server's entry in database has expired"
@@ -302,8 +302,8 @@ filter {
       fallback => "failed service ticket request"
     }
     translate {
-      field => "ticket_encrypt"
-      destination => "[tls][cipher]"
+      source => "ticket_encrypt"
+      target => "[tls][cipher]"
       dictionary => {
         "0x1" => "DES-CBC-CRC"
         "0x3" => "DES-CBC-MD5"


### PR DESCRIPTION
## Description
 use of 'source', 'target' instead of 'field', 'destination'


## Related Issues
Fix deprecation warnings #171


## Todos
NA