### PR TITLE
ip field duplicate values issue fix

### DIFF
--- a/config/enrichments/02_ecs_data_type.conf
+++ b/config/enrichments/02_ecs_data_type.conf
@@ -125,45 +125,42 @@ filter {
     # [log][source][ip]
     if [log][source][ip] {
       if [log][source][ip] !~ "^\d+\.\d+\.\d+\.\d+$" {
-        mutate {
-          add_tag => [ "invalid ip format [log][source][ip]" ]
-          remove_field => ["[log][source][ip]"]
-        }
-      } else {
         if ![log][source][hostname] {
           mutate {
             copy => { "[log][source][ip]" => "[log][source][hostname]" }
           }
+        }
+        mutate {
+          add_tag => [ "invalid ip format [log][source][ip]" ]
+          remove_field => ["[log][source][ip]"]
         }
       }
     }
     # [source][ip]	[source][address]
     if [source][ip] {
       if [source][ip] !~ "^\d+\.\d+\.\d+\.\d+$" {
-        mutate {
-          add_tag => [ "invalid ip format [source][ip]" ]
-          remove_field => ["[source][ip]"]
-        }
-      } else {
         if ![source][address] {
           mutate {
             copy => { "[source][ip]" => "[source][address]" }
           }
+        }
+        mutate {
+          add_tag => [ "invalid ip format [source][ip]" ]
+          remove_field => ["[source][ip]"]
         }
       }
     }
     # [client][ip]	[client][address]
     if [client][ip] {
       if [client][ip] !~ "^\d+\.\d+\.\d+\.\d+$" {
-        mutate {
-          add_tag => [ "invalid ip format [client][ip]" ]
-          remove_field => ["[client][ip]"]
-        }
-      } else {
         if ![client][address] {
           mutate {
             copy => { "[client][ip]" => "[client][address]" }
           }
+        }
+        mutate {
+          add_tag => [ "invalid ip format [client][ip]" ]
+          remove_field => ["[client][ip]"]
         }
       }
     }
@@ -177,15 +174,14 @@ filter {
     # [destination][ip]	[destination][address]
     if [destination][ip] {
       if [destination][ip] !~ "^\d+\.\d+\.\d+\.\d+$" {
-        mutate {
-          add_tag => [ "invalid ip format [destination][ip]" ]
-          remove_field => ["[destination][ip]"]
-        }
-      } else {
         if ![destination][address] {
           mutate {
             copy => { "[destination][ip]" => "[destination][address]" }
           }
+        }
+        mutate {
+          add_tag => [ "invalid ip format [destination][ip]" ]
+          remove_field => ["[destination][ip]"]
         }
       }
     }
@@ -199,30 +195,28 @@ filter {
     # [dns][resolved_ip]	[dns][answers][name]
     if [dns][resolved_ip] {
       if [dns][resolved_ip] !~ "^\d+\.\d+\.\d+\.\d+$" {
-        mutate {
-          add_tag => [ "invalid ip format [dns][resolved_ip]" ]
-          remove_field => ["[dns][resolved_ip]"]
-        }
-      } else {
         if ![dns][answers][name] {
           mutate {
             copy => { "[dns][resolved_ip]" => "[dns][answers][name]" }
           }
+        }
+        mutate {
+          add_tag => [ "invalid ip format [dns][resolved_ip]" ]
+          remove_field => ["[dns][resolved_ip]"]
         }
       }
     }
     # [host][ip]	[host][hostname]
     if [host][ip] {
       if [host][ip] !~ "^\d+\.\d+\.\d+\.\d+$" {
-        mutate {
-          add_tag => [ "invalid ip format [host][ip]" ]
-          remove_field => ["[host][ip]"]
-        }
-      } else {
         if ![host][hostname] {
           mutate {
             copy => { "[host][ip]" => "[host][hostname]" }
           }
+        }
+        mutate {
+          add_tag => [ "invalid ip format [host][ip]" ]
+          remove_field => ["[host][ip]"]
         }
       }
     }
@@ -236,15 +230,14 @@ filter {
     # [observer][ip]	[observer][name]
     if [observer][ip] {
       if [observer][ip] !~ "^\d+\.\d+\.\d+\.\d+$" {
-        mutate {
-          add_tag => [ "invalid ip format [observer][ip]" ]
-          remove_field => ["[observer][ip]"]
-        }
-      } else {
         if ![observer][name] {
           mutate {
             copy => { "[observer][ip]" => "[observer][name]" }
           }
+        }
+        mutate {
+          add_tag => [ "invalid ip format [observer][ip]" ]
+          remove_field => ["[observer][ip]"]
         }
       }
     }
@@ -253,15 +246,14 @@ filter {
     # [server][ip]	[server][address]
     if [server][ip] {
       if [server][ip] !~ "^\d+\.\d+\.\d+\.\d+$" {
-        mutate {
-          add_tag => [ "invalid ip format [server][ip]" ]
-          remove_field => ["[server][ip]"]
-        }
-      } else {
         if ![server][name] {
           mutate {
             copy => { "[server][ip]" => "[server][name]" }
           }
+        }
+        mutate {
+          add_tag => [ "invalid ip format [server][ip]" ]
+          remove_field => ["[server][ip]"]
         }
       }
     }

--- a/config/enrichments/08_host_split.conf
+++ b/config/enrichments/08_host_split.conf
@@ -8,8 +8,10 @@ filter {
     # [client][address] [client][ip] [client][domain]
     if [client][address] =~ "^.*?\..*?$" {
       if [client][address] =~ "^\d+.\d+.\d+.\d+$" {
-        mutate {
-          add_field => { "[client][ip]" => "%{[client][address]}"}
+        if ![client][ip] {
+          mutate {
+            add_field => { "[client][ip]" => "%{[client][address]}"}
+          }
         }
         mutate {
           remove_field =>  [ "[client][address]" ]
@@ -31,8 +33,10 @@ filter {
     # [host][hostname] [host][ip] [host][domain]
     if [host][hostname] =~ "^.*?\..*?$" {
       if [host][hostname] =~ "^\d+.\d+.\d+.\d+$" {
-        mutate {
-          add_field => { "[host][ip]" => "%{[host][hostname]}"}
+        if ![host][ip] {
+          mutate {
+            add_field => { "[host][ip]" => "%{[host][hostname]}"}
+          }
         }
         mutate {
           remove_field =>  [ "[host][hostname]" ]
@@ -54,8 +58,10 @@ filter {
     # [server][address]	[server][ip] [server][domain]
     if [server][address] =~ "^.*?\..*?$" {
       if [server][address] =~ "^\d+.\d+.\d+.\d+$" {
-        mutate {
-          add_field => { "[server][ip]" => "%{[server][address]}"}
+        if ![server][ip] {
+          mutate {
+            add_field => { "[server][ip]" => "%{[server][address]}"}
+          }
         }
         mutate {
           remove_field =>  [ "[server][address]" ]
@@ -77,8 +83,10 @@ filter {
     # [source][address]	[source][ip] [source][domain]
     if [source][address] =~ "^.*?\..*?$" {
       if [source][address] =~ "^\d+.\d+.\d+.\d+$" {
-        mutate {
-          add_field => { "[source][ip]" => "%{[source][address]}"}
+        if ![source][ip] {
+          mutate {
+            add_field => { "[source][ip]" => "%{[source][address]}"}
+          }
         }
         mutate {
           remove_field =>  [ "[source][address]" ]
@@ -100,8 +108,10 @@ filter {
     # [log][source][hostname] [log][source][ip]	[log][source][domain]
     if [log][source][hostname] =~ "^.*?\..*?$" {
       if [log][source][hostname] =~ "^\d+.\d+.\d+.\d+$" {
-        mutate {
-          add_field => { "[log][source][ip]" => "%{[log][source][hostname]}"}
+        if ![log][source][ip] {
+          mutate {
+            add_field => { "[log][source][ip]" => "%{[log][source][hostname]}"}
+          }
         }
         mutate {
           remove_field =>  [ "[log][source][hostname]" ]

--- a/config/enrichments/17_dns.conf
+++ b/config/enrichments/17_dns.conf
@@ -166,28 +166,6 @@ filter {
         }
       }
     }
-    if [log][source][ip] and ![log][source][ip][0] and ![log][source][hostname] {
-      mutate {
-        add_field => {
-          "[log][source][hostname]" => "%{[log][source][ip]}"
-        }
-      }
-      dns {
-        nameserver => [VAR_DNS_SERVER]
-        reverse => ["[log][source][hostname]"]
-        action => "replace"
-        max_retries => 0
-        hit_cache_size => 500000
-        hit_cache_ttl => 3600
-        failed_cache_size => 500000
-        failed_cache_ttl => 3600
-      }
-      if [log][source][hostname] =~ "^(\d+\.\d+\.\d+\.\d+|[0-9a-zA-Z]+:.*?:.*?:.*?:.*?:.*?:.*?:[0-9a-zA-Z]+)$" {
-        mutate {
-          remove_field => ["[log][source][hostname]"]
-        }
-      }
-    }
     if [observer][ip] and ![observer][ip][0] and ![observer][hostname] {
       mutate {
         add_field => {


### PR DESCRIPTION
## Description
- check if hostname/address fields exists before copying respective ip fields values (only if they are not in ip format) to them
- checking if ip fields exists before copying address fields to them (only if the address fields values are in ip format)
- removed duplicate condition for log.source.hostname dns lookup


## Related Issues
No


## Todos
NA