### PR TITLE
strip message field before parsing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,7 +69,8 @@ jobs:
         && ${LOGSTASH_HOME}/bin/logstash-plugin install \
         logstash-input-okta_system_log \
         logstash-filter-json_encode \
-        logstash-filter-tld
+        logstash-filter-tld \
+        logstash-output-opensearch
     - name: Generate pipelines
       env:
         # See README.md for explaination

--- a/config/outputs/elastic_output.conf
+++ b/config/outputs/elastic_output.conf
@@ -4,14 +4,12 @@ input {
   pipeline { address => elastic_output }
 }
 output {
-  elasticsearch {
+  opensearch {
     hosts => [VAR_ELASTIC_SERVERS]
     index => "%{[@metadata][output]}"
     ssl => true
     ssl_certificate_verification => false
     user => "VAR_ELASTIC_USER"
     password => "VAR_ELASTIC_PASSWORD"
-    ilm_enabled => false
   }
 }
-

--- a/config/processors/api_log_security_mcafee.mcp_v5.conf
+++ b/config/processors/api_log_security_mcafee.mcp_v5.conf
@@ -10,6 +10,9 @@ filter {
   if ![message] or [message] == "" {
     drop {}
   }
+  mutate {
+    strip => ["message"]
+  }
   csv {
     source => "message"
     columns => ["num","usr","[source][nat][ip]","[http][request][method]","[destination][bytes]","[source][bytes]","[url][domain]","[url][path]","[event][action]","[rule][name]","request_timestamp_epoch","[event][time]","[url][scheme]","[rule][category]","[http][request][body][content]","[service][name]","[event][severity_name]", "[rule][uuid]", "[http][response][status_code]", "[source][ip]", "[rule][description]", "[rule][ruleset]", "[user_agent][original]", "[user_agent][name]", "[user_agent][version]", "[process][name]", "[destination][ip]", "[destination][port]"]

--- a/config/processors/api_log_security_mcafee.mcp_v5.conf
+++ b/config/processors/api_log_security_mcafee.mcp_v5.conf
@@ -7,11 +7,11 @@ input {
 }
 filter {
   ### McAfee MCP API, tested against API v1-v5
-  if ![message] or [message] == "" {
-    drop {}
-  }
   mutate {
     strip => ["message"]
+  }
+  if ![message] or [message] == "" {
+    drop {}
   }
   csv {
     source => "message"


### PR DESCRIPTION
## Description
Strip the message for leading and trailing whitespace before parsing. Logs usually end with new line character. This PR intends to solve that.


## Related Issues
Are there any Issues to this PR? 


## Todos
Are there any additional items that must be completed before this PR gets merged in?
- [ ] 
- [ ] 