### PR TITLE
pod: adding envelope.rcpts to destination.user.email

### DIFF
--- a/config/processors/api_log_security_proofpoint.pod_email_gateway.conf
+++ b/config/processors/api_log_security_proofpoint.pod_email_gateway.conf
@@ -5,7 +5,7 @@ input {
     address => VAR_PIPELINE_NAME
   }
 }  
-filter {  
+filter {
   mutate {
     add_field => {"[log][source][hostname]" => "api_proofpoint_pod"}
     copy => {"message" => "tmp_msg"}
@@ -21,7 +21,7 @@ filter {
   }
   mutate {
     rename => { "[pp][msg][parsedAddresses][from]" => "[source][user][email]" }
-    rename => { "[pp][msg][parsedAddresses][to]" => "[destination][user][email]" }
+    rename => { "[pp][envelope][rcpts]" => "[destination][user][email]" }
     merge => { "[destination][user][email]" => "[pp][msg][parsedAddresses][cc]" }
     rename => { "[pp][msg][normalizedHeader][subject]" => "[email][subject]" }
     rename => { "[pp][ts]" => "[event][created]" }
@@ -117,6 +117,11 @@ filter {
     "
     tag_on_exception => "actions_ruby_block"
   }
+  if [pp][msg][parsedAddresses][to][0] !~ '^.*undisclosed.*$' {
+    mutate {
+      merge => { "[destination][user][email]" => "[pp][msg][parsedAddresses][to]" }
+    }
+  }
   if [pp][connection][protocol] {
     dissect {
       mapping => {
@@ -137,11 +142,11 @@ filter {
     tag_on_failure => "_dateparsefailure_ec"
   }
   if "_dateparsefailure_ec" in [tags]  {
-      if ![log][original] {
-        mutate {
-            copy => { "message" => "[log][original]" }
-          }
+    if ![log][original] {
+      mutate {
+        copy => { "message" => "[log][original]" }
       }
+    }
     mutate {
       remove_field => ["[event][created]"]
     }
@@ -154,11 +159,11 @@ filter {
     tag_on_failure => "_dateparsefailure_es"
   }
   if "_dateparsefailure_es" in [tags]  {
-      if ![log][original] {
-        mutate {
-            copy => { "message" => "[log][original]" }
-          }
+    if ![log][original] {
+      mutate {
+        copy => { "message" => "[log][original]" }
       }
+    }
     mutate {
       remove_field => ["[event][start]"]
     }


### PR DESCRIPTION
## Description
@verbecee following are the changes I made
- adding envelope.rcpts to destination.user.email
- check if 'to' field is not one of either "undisclosed recipients:;" or "undisclosed-recipients:;" , then merge 'to' field values to destination.user.email
- indentation changes


## Related Issues
No


## Todos
NA