### PR TITLE
forescout.nac: moved mutate copy plugin

### DIFF
--- a/config/processors/syslog_log_security_forescout.counteract.nac.conf
+++ b/config/processors/syslog_log_security_forescout.counteract.nac.conf
@@ -275,8 +275,10 @@ filter {
   if [host][hostname] and ([host][hostname] != "" or [host][hostname][0] != "" ){
     mutate {
       copy => { "[host][hostname]" => "[host][name]" }
-	  copy => { "[host][hostname]" => "[log][source][hostname]" }
     }
+  }
+  mutate {
+    copy => { "[host][hostname]" => "[log][source][hostname]" }
   }
 }
 output {


### PR DESCRIPTION
## Description
copying same field to 2 different fields was causing mutate error - so moved copy plugin to different mutate filter.


## Related Issues
No


## Todos
NA