### PR TITLE
palo.alto: dateparse failure fix

### DIFF
--- a/config/processors/syslog_log_security_palo.alto.fw.conf
+++ b/config/processors/syslog_log_security_palo.alto.fw.conf
@@ -396,19 +396,26 @@ filter {
       add_field => { "[event][dataset]" => "palo.alto.fw_audit" }
       add_field => { "[log][source][hostname]" => "palo.alto.fw_audit" }
     }
-    grok {
-      tag_on_failure => "_parsefailure_system"
-      match => { "message" => ".*?,.*?,(?<[event][provider]>.*?,.*?),.*?,(?<[date]>.*?),.*?,(?<[event][category]>.*?),.*?,.*?,.*?,.*?,.*?,(?<[rule][description]>.*?),.*?" }
-      timeout_millis => 500
+    json {
+      source => "message"
+      target => "tmp"
+    }
+    dissect {
+      mapping => {
+        '[tmp][message]' => '%{?data} %{?data} %{?data} %{[event][provider]} %{?data},%{date} %{+date},%{?data},%{[event][category]},%{?data},%{?data},%{?data},%{?data},%{?data},%{?data},%{?data},%{?data},%{?data},%{?data},"%{[rule][description]}",%{?data},%{?data},%{?data},%{?data},%{?data},%{?data},%{?data},%{?data},%{?data},%{?data},%{?data}'
+      }
     }
     mutate {
       add_field => { "[agent][parse_rule]" => "Rule 2" }
       copy => { "message" => "[log][original]" }
     }
-    if [rule][description] =~ "User" {
+    mutate {
+      strip => [ "[rule][description]" ]
+    }
+    if [rule][description] =~ "initiated" {
       grok {
         tag_on_failure => "_parsefailure_user_ip"
-        match => { "[rule][description]" => "^.*?User (?<[source][user][name]>.*?) .*?from(:)? (?<[source][ip]>\d+\.\d+\.\d+\.\d+)" }
+        match => { "[rule][description]" => "^.*?initiated by (?<[source][ip]>\d+\.\d+\.\d+\.\d+)" }
         timeout_millis => 500
       }
     }
@@ -442,7 +449,7 @@ filter {
     }
   }
   mutate {
-    remove_field => [ "actual_msg", "date" ]
+    remove_field => [ "actual_msg", "date", "tmp" ]
   }
 }
 output {


### PR DESCRIPTION
## Description
- grok changed to dissect to avoid grok timeout
- new grok pattern to parse source.ip
- fix for dateparse failure


## Related Issues
No


## Todos
NA