### PR TITLE
cisco.ise avoid parsefailures and clean up data

### DIFF
--- a/config/processors/syslog_security_cisco.ise.conf
+++ b/config/processors/syslog_security_cisco.ise.conf
@@ -205,23 +205,30 @@ filter {
     rename => { "[kvs][timezone]" => "[@metadata][timezone]"}
     remove_field => ["[kvs][FailureReason]"]
   }
-  mutate {
-    gsub => [ "proc_tmp", "\[\]", "" ]
-    strip => [ "proc_tmp" ]
-  }
-  mutate {
-    gsub => [
-	  "proc_tmp", "\[\]", "",
-	  "proc_tmp", "CmdArgAV=", "",
-	  "proc_tmp", "<cr>", ""
-      ]
-	strip => [ "proc_tmp" ]
-  }
-  grok {  
-    match => {
-      "proc_tmp" => "^CmdAV=(?<[process][command_line]>.*?)(\s\<cr\>)?$"
+  if [proc_tmp] {
+    mutate {
+      gsub => [ "proc_tmp", "\[\]", "" ]
+      strip => [ "proc_tmp" ]
     }
-  } 
+    mutate {
+      gsub => [
+            "proc_tmp", "\[\]", "",
+            "proc_tmp", "CmdArgAV=", "",
+            "proc_tmp", "<cr>", ""
+        ]
+          strip => [ "proc_tmp" ]
+    }
+    grok {
+      match => {
+        "proc_tmp" => "^CmdAV=(?<[process][command_line]>.*?)(\s\<cr\>)?$"
+      }
+    }
+  }
+  if [kvs][AdminIPAddress] {
+    mutate {
+      gsub => [ "[kvs][AdminIPAddress]", "[\\, ]", "" ]
+    }
+  }
 
   # 8. Convert fields (i.e. extract site, appliance type, etc)
   if [tmp][segment_number] == "0" and [host][hostname]


### PR DESCRIPTION
when proc_tmp doesn't exist , a grok parse failure happens, therefore only handle operations if the field exists.

also, clean up the field [kvs][AdminIPAddress] from unwanted symbols.

an example log message is the below

```
<181>Nov 29 08:18:39 MGT-ISE-01 CISE_Administrative_and_Operational_Audit 0000452176 1 0 2022-11-29 08:18:39.066 +00:00 0001375211 61025 NOTICE EAP-TLS: Open secure connection with TLS peer, ConfigVersionId=441, AdminInterface=UNKNOWN, AdminIPAddress=192.168.40.120\, , OperationMessageText=Connection created from 192.168.8.120:39187 to  169.254.2.4:5671, AcsInstance=MGT-ISE-01, 
```

caused to have

`[kvs][AdminIPAddress]` being equal to `192.168.40.120\\,`

## Description
Please provide a description of your proposed changes - providing obfuscated log/code examples is highly encouraged.


## Related Issues
Are there any Issues to this PR? 


## Todos
Are there any additional items that must be completed before this PR gets merged in?
- [ ] 
- [ ] 