### PR TITLE
added field for AWS Guard duty test alerts.

### DIFF
--- a/config/processors/api_security_aws.guardduty.conf
+++ b/config/processors/api_security_aws.guardduty.conf
@@ -18,6 +18,7 @@ filter {
   } 
   mutate {
     tag_on_failure => "mutate 1 failure"
+    rename => { "[guard][additionalinfo][sample]" => "[event][type]" }
     rename => { "[guard][severity]" => "[event][severity]" }
     rename => { "[guard][createdAt]" => "[event][created]" }
     rename => { "[guard][updatedAt]" => "[event][modified]" }


### PR DESCRIPTION
## Description
AWS Guard duty can send test alerts. Parsing has been added to map test field to ECS so test alerts can be filtered on


## Related Issues
Are there any Issues to this PR? 


## Todos
Are there any additional items that must be completed before this PR gets merged in?
- [ ] 
- [ ] 