### PR TITLE
Fix error: implicit conversion of nil into String

### DIFF
--- a/config/enrichments/94_remove_empty_n_truncate.conf
+++ b/config/enrichments/94_remove_empty_n_truncate.conf
@@ -63,17 +63,19 @@ filter {
         invalid_value_list = ["-", "null", "nil", "n/a", "\'\'"]
 
         def walk_hash(parent, path, hash)
+          paths = []
           path << parent if parent
           hash.each do |key, value|
-            walk_hash(key, path, value) if value.is_a?(Hash)
-            @paths << (path + [key]).map {|p| "[" + p + "]" }.join("")
+            paths += walk_hash(key, path, value) if value.is_a?(Hash)
+            computed_path = (path + [key]).map {|p| "[" + p.to_s + "]" }.join("")
+            paths << computed_path
           end
           path.pop
+          return paths
         end
 
-        @paths = []
-        walk_hash(nil, [], event.to_hash)
-        @paths.each do |k|
+        paths = walk_hash(nil, [], event.to_hash)
+        paths.each do |k|
           v = event.get(k)
           if v.nil? || (v.respond_to?(:empty?) && v.empty?)
             event.remove(k)
@@ -89,7 +91,7 @@ filter {
                   next
                 else
                   event.set(k, v.to_s[0, 1023])
-		end
+		            end
               end
             else
               # check if its an array


### PR DESCRIPTION
## Description
The enrichment is meant to be used by multiple workers and hence support concurrent execution. The variable `path` was defined as an instance variable that was causing unsafe concurrent modifications and hence errors. Updated the code to fix it.

## Related Issues
Are there any Issues to this PR? 
Fixes https://github.com/Cargill/OpenSIEM-Logstash-Parsing/issues/374