### PR TITLE
Removed square brackets from data in SWG

### DIFF
--- a/config/processors/syslog_security_skyhigh.swg.conf
+++ b/config/processors/syslog_security_skyhigh.swg.conf
@@ -152,7 +152,11 @@ if [tmp_csv] !~ "\w,\w" {
       add_field => { "[event][action]" => "denied" }
     }
   }
-  
+  mutate {
+    gsub => [
+      "[event][created]", "[\[\]]", ""
+    ]
+  }  
   if [event][created] {
     date {
       # "26/aug/2020:19:35:09.533 +0000"


### PR DESCRIPTION
## Description
SKY high SWG sometimes has square brackets in Date fields for some events invalidating date format. This change fixes date parsing errors. 


## Related Issues
Are there any Issues to this PR? 


## Todos
Are there any additional items that must be completed before this PR gets merged in?
- [ ] 
- [ ] 