### PR TITLE
Added remove host to rsyslog incase ecs is not configured correctly

### DIFF
--- a/config/processors/syslog_audit_linux_rsyslog.conf
+++ b/config/processors/syslog_audit_linux_rsyslog.conf
@@ -9,6 +9,7 @@ filter {
   mutate {
     add_field => { "[event][module]" => "linux" }
     add_field => { "[event][dataset]" => "linux.rsyslog" }
+    remove_field => [ "host" ]
   }
   mutate {
     replace => {


### PR DESCRIPTION
## Description
If agent is set to ecs=disabled, then agent.name is int host field, this prevents logs from failing to parse because host = x is set


## Related Issues
Are there any Issues to this PR? 


## Todos
Are there any additional items that must be completed before this PR gets merged in?
- [ ] 
- [ ] 