### PR TITLE
Will now handle non-split and split message field examples

### DIFF
--- a/config/processors/event_hub_audit_azure.event_hub_interactive_signin.conf
+++ b/config/processors/event_hub_audit_azure.event_hub_interactive_signin.conf
@@ -45,46 +45,6 @@ filter {
       rename => { "tmp" => "az"}
     }
   }
-  json {
-    source => "[az][networklocationdetails]"
-    target => "[az][networklocationdetails]" 
-    tag_on_failure => "_jsonparsefailure_network"
-  }
-  json {
-    source => "[az][devicedetail]"
-    target => "[az][devicedetail]"
-    tag_on_failure => "_jsonparsefailure_device"
-  }
-  json {
-    source => "[az][locationdetails]"
-    target => "[az][locationdetails]"
-    tag_on_failure => "_jsonparsefailure_location"
-  }
-  json {
-    source => "[az][authenticationprocessingdetails]"
-    target => "[az][authenticationprocessingdetails]"
-    tag_on_failure => "_jsonparsefailure_auth_proc"
-  }
-  json {
-    source => "[az][authenticationdetails]"
-    target => "[az][authenticationdetails]"
-    tag_on_failure => "_jsonparsefailure_auth_detail"
-  }
-  json {
-    source => "[az][authenticationrequirementpolicies]"
-    target => "[az][authenticationrequirementpolicies]"
-    tag_on_failure => "_jsonparsefailure_auth_policy"
-  }
-  json {
-    source => "[az][conditionalaccesspolicies]"
-    target => "[az][conditionalaccesspolicies]"
-    tag_on_failure => "_jsonparsefailure_conditional"
-  }
-  json {
-    source => "[az][status]"
-    target => "[az][status]"
-    tag_on_failure => "_jsonparsefailure_status"
-  }
   ### lowercase all field names
   ruby {
     init => '@ignore = [ "path", "@timestamp", "@metadata", "host", "@version" ]'

--- a/config/processors/event_hub_audit_azure.event_hub_interactive_signin.conf
+++ b/config/processors/event_hub_audit_azure.event_hub_interactive_signin.conf
@@ -12,6 +12,13 @@ filter {
   mutate{
     add_field => { "[event][module]" => "azure" }
     add_field => { "[event][dataset]" => "azure.interactivesignin" }
+    gsub => [ 
+      "message", '\\+"', '"',
+      "message", '"\[', '[',
+      "message", '\]"', ']',
+      "message", '\}"', '}',
+      "message", '"\{', '{'
+    ]
   }
    json {
       source => "message" 


### PR DESCRIPTION
## Description
After logs are split, and message field is json_encoded when parsing updates are needed this process the raw message field seen in kibana. 


## Related Issues
Are there any Issues to this PR? 


## Todos
Are there any additional items that must be completed before this PR gets merged in?
- [ ] 
- [ ] 