### PR TITLE
Azure Interactive signin has bad json string {PII Removed}

### DIFF
--- a/config/processors/event_hub_audit_azure.event_hub_interactive_signin.conf
+++ b/config/processors/event_hub_audit_azure.event_hub_interactive_signin.conf
@@ -18,6 +18,7 @@ filter {
       "message", '\]"', ']',
       "message", '\}"', '}',
       "message", '"\{', '{'
+      "message", '{PII Removed}', '"PII Removed"'
     ]
   }
    json {

--- a/config/processors/event_hub_audit_azure.event_hub_interactive_signin.conf
+++ b/config/processors/event_hub_audit_azure.event_hub_interactive_signin.conf
@@ -17,7 +17,7 @@ filter {
       "message", '"\[', '[',
       "message", '\]"', ']',
       "message", '\}"', '}',
-      "message", '"\{', '{'
+      "message", '"\{', '{',
       "message", '{PII Removed}', '"PII Removed"'
     ]
   }


### PR DESCRIPTION
## Description
Looks like Azure is replacing PII data with invalid json value of "deviceId": {PII Removed},"displayName": {PII Removed}. Although I cannot imagine why they would consider this data PII.

This bad json value was causing json parsing and record split to fail.

## Related Issues
Are there any Issues to this PR? 


## Todos
Are there any additional items that must be completed before this PR gets merged in?
- [ ] 
- [ ] 