### PR TITLE
added a second lowercase fieldnames to defendor logs

### DIFF
--- a/config/processors/event_hub_audit_azure.event_hub_securityalert.conf
+++ b/config/processors/event_hub_audit_azure.event_hub_securityalert.conf
@@ -57,6 +57,11 @@ filter {
     target => "[az][remediationsteps]"
     skip_on_invalid_json => true
   }   
+  # lowercase field names
+  ruby {
+    path => "${LOGSTASH_HOME}/config/lower.rb"
+    tag_on_exception => "_lowecase_ruby_block"
+  }
   mutate {
     add_field => { 
       "[event][module]" => "azure"


### PR DESCRIPTION
## Description
Had to lower case fieldname after intial json and after subsequesnt jsopn parsing


## Related Issues



## Todos

- [ ] 
- [ ] 