### PR TITLE
as400 syslog logs with tcp input does not have syslog header

### DIFF
--- a/config/processors/syslog_as400_audit.conf
+++ b/config/processors/syslog_as400_audit.conf
@@ -7,29 +7,24 @@ input {
 }
 filter {
   mutate {
+    remove_field => [ "event", "host" ]
+  }
+  mutate {
     add_field => {
       "[event][module]" => "as400"
       "[event][dataset]" => "as400.audit"
     }
-    lowercase => [ "message" ]
-  }
-  grok {
-    tag_on_failure => "_parsefailure_header"
-    match => { "message" => "^(.*?{name=.*?}(\s)?)?(<(?<pri>\d+)>)?(\s)?(?<actual_msg>.*)$|(^(?<actual_msg>.*)$)" }
-    timeout_millis => 500
-  }
-  syslog_pri {
-    syslog_pri_field_name => "pri" 
-    remove_field => [ "pri" ]
   }
   json {
-    source => "actual_msg"
+    source => "message"
     target => "tmp"
+  }
+  ruby {
+    path => "${LOGSTASH_HOME}/config/lower.rb"
+    tag_on_exception => "_lowecase_ruby_block"
   }
   mutate {
     rename => {
-      "[tmp][a_date]" => "date"
-      "[tmp][b_time]" => "time"
       "[tmp][c_system]" => "[host][name]"
       "[tmp][d_event]" => "[event][id]"
       "[tmp][e_command]" => "[process][command_line]"
@@ -45,7 +40,7 @@ filter {
     }
   }
   mutate {
-    add_field => { "[event][created]" => "%{date} %{time}" }
+    add_field => { "[event][created]" => "%{[tmp][a_date]} %{[tmp][b_time]}" }
   }
   #2023-02-08 07.03.36
   date {
@@ -56,7 +51,7 @@ filter {
     tag_on_failure => "_dateparsefailure_ec"
   }
   mutate {
-    remove_field => [ "actual_msg", "tmp", "date", "time", "[log][original]" ]
+    remove_field => [ "tmp" ]
   }
 }
 output {


### PR DESCRIPTION
## Description
AS400 syslog logs with a tcp input does not have a syslog header, the format is JSON. This removes syslog header parsing and PRI filter. 


## Related Issues
Are there any Issues to this PR? 


## Todos
Are there any additional items that must be completed before this PR gets merged in?
- [ ] 
- [ ] 