### PR TITLE
Checkpoint time field

### DIFF
--- a/config/processors/syslog_audit_checkpoint.fw.conf
+++ b/config/processors/syslog_audit_checkpoint.fw.conf
@@ -9,7 +9,7 @@ filter {
   mutate {
     add_field => { "[event][module]" => "checkpoint" }
     add_field => { "[event][dataset]" => "checkpoint.fw" }
-    add_field => { "[log][source][hostname]" => "checkpoint_fw" }
+    remove_field => [ "host" ]	
   }
   grok {
     tag_on_failure => "_parsefailure_header"
@@ -131,7 +131,7 @@ filter {
     rename => {"[fw][protection_id]" => "[rule][id]"}
   }
   date {
-    match => ["[fw][date]", "UNIX"]
+    match => ["[fw][time]", "UNIX"]
     timezone => "GMT"
     locale => "en"
     target => "[event][created]"


### PR DESCRIPTION
## Description
Checkpoint logs have 2 date/time fields it turns out that the time field aligns closer to the time field aligns closer to actual time if event.


## Related Issues
Are there any Issues to this PR? 


## Todos
Are there any additional items that must be completed before this PR gets merged in?
- [ ] 
- [ ] 