### PR TITLE
Snmp log format grok change

### DIFF
--- a/config/processors/snmp_forescout.conf
+++ b/config/processors/snmp_forescout.conf
@@ -16,7 +16,7 @@ filter {
     split => { "message" => "|||DELIM|||" }
   }
 
-  # split the field into actual multiple events
+  # split the field into actual multiple events 
   split { field => "message" }
   
   # Remove leading delimiter if present

--- a/config/processors/snmp_forescout.conf
+++ b/config/processors/snmp_forescout.conf
@@ -7,21 +7,43 @@ input {
 }
 filter {
   mutate {
+    gsub => [
+      # add delimiter before any new-event prefix
+      "message", "(?=(?:\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2},\d{3}))", "|||DELIM|||"
+    ]
+  }
+  mutate {
+    split => { "message" => "|||DELIM|||" }
+  }
+
+  # split the field into actual multiple events
+  split { field => "message" }
+  
+  # Remove leading delimiter if present
+  mutate {
+      gsub => [ "message", "^\|\|\|DELIM\|\|\|", "" ]
+  }
+  mutate {
     add_field => { "[event][module]" => "forescout" }
     add_field => { "[event][dataset]" => "forescout.counteract_snmp_traps" }
     add_field => { "[log][source][hostname]" => "forescout_counteract_snmp_traps" }
   }
-  dissect {
-    tag_on_failure => "_dissectfailure"
-    mapping => {
-      "message" => "%{[data]} MESSAGE %{[[rest_msg]]}"
+
+  grok {
+    match => {
+      "message" => [
+          # Pattern with timestamp
+          "%{GREEDYDATA:data} MESSAGE %{GREEDYDATA:rest_msg}",
+          # Pattern without timestamp
+          "%{GREEDYDATA:rest_msg}"
+      ]
     }
   }
 
   mutate {
     gsub => [
-       "rest_msg", "(.\d+ =)", " ="
-      ]
+      "rest_msg", "(.\d+ =)", " ="
+    ]
   }
 
   kv {
@@ -31,7 +53,7 @@ filter {
     value_split => "="
     ##trim_key => " "
     transform_key => "lowercase"
- }
+  }
   mutate {
     rename => { "[oid][forescout-mib::fstrapseverity ]" => "[event][severity_name]" }
     rename => { "[oid][forescout-mib::ctdeviceipaddress ]" => "[source][ip]" }


### PR DESCRIPTION
## Description
- delimit logs using split
- grok to get rest_msg - work for both formats (with or without timestamp)


## Related Issues
NA


## Todos
NA