### PR TITLE
cloudtrail ruby fix

### DIFF
--- a/config/processors/api_audit_aws.cloudtrail.conf
+++ b/config/processors/api_audit_aws.cloudtrail.conf
@@ -52,8 +52,13 @@ filter {
   }
   ruby {
     code => "
-      name = event.get('[aws][requestParameters][key][Path]') || event.get('[aws][requestParameters][key]')
-      event.set('[file][name]', name)
+      key = event.get('[aws][requestParameters][key]')
+      if key.is_a?(Hash)
+        path = key['Path']
+        event.set('[file][name]', path) unless path.nil?
+      else
+        event.set('[file][name]', key) unless key.nil?
+      end
     "
   }
   if [aws][userIdentity][arn] {


### PR DESCRIPTION
## Description
- check if 'key' is hash
- check if 'path' exists under 'key'
- if 'path' exists and is not null, then parse it under file.name
- else if 'key' is not hash and is not null, then string value would be file.name 