### PR TITLE
waf log drop error fix

### DIFF
--- a/config/processors/api_azure_graph_api_incidences_api.conf
+++ b/config/processors/api_azure_graph_api_incidences_api.conf
@@ -319,14 +319,14 @@ filter {
   }
 # 2025-01-15T14:42:00Z
   date {
-    match => ["[event][start][0]", "yyyy-MM-dd'T'HH:mm:ss'Z'" ]
+    match => ["[event][start][0]", "ISO8601", "yyyy-MM-dd't'HH:mm:ss'z'" ]
     timezone => "GMT"
     locale => "en"
     target => "[event][start]"
     tag_on_failure => "_dateparsefailure_es"
   }
   date {
-    match => ["[event][end][0]", "yyyy-MM-dd'T'HH:mm:ss'Z'" ]
+    match => ["[event][end][0]", "ISO8601", "yyyy-MM-dd't'HH:mm:ss'z'" ]
     timezone => "GMT"
     locale => "en"
     target => "[event][end]"

--- a/config/processors/api_network_aws.secuirty_lake_waf.conf
+++ b/config/processors/api_network_aws.secuirty_lake_waf.conf
@@ -27,7 +27,6 @@ filter {
     path => "${LOGSTASH_HOME}/config/lower.rb"
     tag_on_exception => "_lowecase_ruby_block"
   }
-
   
   mutate {
     rename => { 
@@ -38,8 +37,7 @@ filter {
       "[aws][http_request][url][path]" => "[url][path]"
       "[aws][http_request][url][hostname]" => "[url][domain]"
       "[aws][http_request][http_method]" => "[http][request][method]"
-      "[aws][http_request][user_agent]" => "[user_agent][name]" 
-      "[aws][http_request][x_forwarded_for][array]" => "[network][forwarded_ip]"
+      "[aws][http_request][user_agent]" => "[user_agent][name]"
       "[aws][http_request][args]" => "[process][args]"
       "[aws][http_request][version]" => "[http][version]"
       "[aws][category_uid]" => "[rule][category]"
@@ -59,7 +57,18 @@ filter {
       "[aws][severity_id]" => "[event][severity]"
       "[aws][type_name]" => "[event][code]"
     }
-  }		  
+  }
+  mutate {
+    join => { "[aws][http_request][x_forwarded_for][array]" => "," }
+  }
+  mutate {
+    split => { "[aws][http_request][x_forwarded_for][array]" => "," }
+  }
+  mutate {
+    add_field => {
+      "[network][forwarded_ip]" => "%{[aws][http_request][x_forwarded_for][array][0]}"
+    }
+  }	  
   grok {
     match => { "[cloud][instance][id]" => "^(?<[cloud][account][id]>.*?)-" }
   }

--- a/config/processors/log_rundeck.conf
+++ b/config/processors/log_rundeck.conf
@@ -11,7 +11,8 @@ filter {
     add_field => { "[event][module]" => "rundeck" }
     add_field => { "[event][dataset]" => "rundeck.agent" }
     copy => { "[beat][hostname]" => "[log][source][hostname]" }
-    update => { "message" => "[event][original]" }
+    update => { "message" => "%{[event][original]}" }
+    rename => { "user" => "[user][name]" }
   }
   mutate {
     rename => {
@@ -30,11 +31,6 @@ filter {
       "role" => "[user][roles]"
       "[fields][environment]" => "[group][name]"
     }
-  }
-  date {
-    match => [ "[event][created]", "ISO8601" ]
-    target => "[event][created]"
-    tag_on_failure => "_dateparsefailure_ec"
   }
   mutate {
     remove_field => [ "beat" , "input", "topic_name", "offset", "@version", "fields", "prospector", "level", "[event][original]" ]


### PR DESCRIPTION
## Description

**waf**:
- getting [http_request][x_forwarded_for][array] field as comma separated string of ip.s ( ["x.x.x.x, x.x.x.x"] )
- which is causing issue when merged with [related][ip]
- so joining them and splitting on ',' then taking first value of array as [network][forwarded_ip] to be later merged to [related][ip]
**rundeck**:
- it was failing as 'user' coming as concrete value and we trying to add nested level field in logstash. So have to rename the 'user'.
- '@timestamp' is renamed as '[event][created]'. So, it is already timestamp format. So, date filter plugin would throw an error as it expects the field to be in 'string' format. So removed date plugin.
**azure graph api**:
- date format change - date coming in both lower and upper case (yyyy-MM-dd't'HH:mm:ss'z' and yyyy-MM-dd'T'HH:mm:ss'Z')