### PR TITLE
removed file.created - securityonion.zeek

### DIFF
--- a/config/processors/syslog_securityonion_securityonion.zeek.conf
+++ b/config/processors/syslog_securityonion_securityonion.zeek.conf
@@ -41,7 +41,6 @@ filter {
     rename => { "[tmp][community_id]" => "[rule][uuid]" }
     rename => { "[tmp][orig_mac_oui]" => "[network][name]" }
     rename => { "[tmp][times.modified]" => "[file][mtime]" }
-    rename => { "[tmp][times.created]" => "[file][created]" }
     rename => { "[tmp][times.changed]" => "[file][ctime]" }
     rename => { "[tmp][times.accessed]" => "[file][accessed]" }
     rename => { "[tmp][protoqtype_name]" => "[dns][question][type]" }
@@ -563,13 +562,6 @@ filter {
     locale => "en"
     target => "[file][mtime]"
     tag_on_failure => "_dateparsefailure_fmt"
-  }
-  date {
-    match => [ "[file][created]", "UNIX" ]
-    timezone => "GMT"
-    locale => "en"
-    target => "[file][created]"
-    tag_on_failure => "_dateparsefailure_fc"
   }
   date {
     match => [ "[file][ctime]", "UNIX" ]

--- a/config/processors/syslog_securityonion_securityonion.zeek.conf
+++ b/config/processors/syslog_securityonion_securityonion.zeek.conf
@@ -40,9 +40,6 @@ filter {
     rename => { "[tmp][duration]" => "[event][duration]" }
     rename => { "[tmp][community_id]" => "[rule][uuid]" }
     rename => { "[tmp][orig_mac_oui]" => "[network][name]" }
-    rename => { "[tmp][times.modified]" => "[file][mtime]" }
-    rename => { "[tmp][times.changed]" => "[file][ctime]" }
-    rename => { "[tmp][times.accessed]" => "[file][accessed]" }
     rename => { "[tmp][protoqtype_name]" => "[dns][question][type]" }
     rename => { "[tmp][query]" => "[dns][question][name]" }
     rename => { "[tmp][answers]" => "[dns][answers]" }
@@ -555,27 +552,6 @@ filter {
     locale => "en"
     target => "[tls][client][not_after]"
     tag_on_failure => "_dateparsefailure_tcnf"
-  }
-  date {
-    match => [ "[file][mtime]", "UNIX" ]
-    timezone => "GMT"
-    locale => "en"
-    target => "[file][mtime]"
-    tag_on_failure => "_dateparsefailure_fmt"
-  }
-  date {
-    match => [ "[file][ctime]", "UNIX" ]
-    timezone => "GMT"
-    locale => "en"
-    target => "[file][ctime]"
-    tag_on_failure => "_dateparsefailure_fct"
-  }
-  date {
-    match => [ "[file][accessed]", "UNIX" ]
-    timezone => "GMT"
-    locale => "en"
-    target => "[file][accessed]"
-    tag_on_failure => "_dateparsefailure_fa"
   }
   date {
     match => [ "[event][created]", "UNIX" ]


### PR DESCRIPTION
## Description
- Removed the times.modified, times.created, times.changed, times.accessed fields mappings because the primary timestamp (ts) already contains the correct event time. And rest has ntlm64 bit timestamps.