### PR TITLE
updated grok setting

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Set logstash variables to be used accross steps
       run: |
-        export LOGSTASH_VERSION=7.16.2
+        export LOGSTASH_VERSION=9.4.0
         export LOGSTASH_HOME="/usr/share/logstash"
         echo "LOGSTASH_VERSION=$LOGSTASH_VERSION" >> $GITHUB_ENV
         echo "LOGSTASH_HOME=$LOGSTASH_HOME" >> $GITHUB_ENV

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,11 +15,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v2
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.14
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: 3.14
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/config/processors/api_ois_sap_security_bridge.conf
+++ b/config/processors/api_ois_sap_security_bridge.conf
@@ -74,15 +74,18 @@ filter {
     }
   }
   grok {
-      match => { "[tmp][timestamp]" => "^(\/Date\()(?<[event][created]>.*?)(\)\/)$" }
-      match => { "[tmp][recTimestamp]" => "^(\/Date\()(?<[event][modified]>.*?)(\)\/)$" }
+      match => {
+        "[tmp][timestamp]" => "^\/Date\((?<[event][created]>\d+)\)\/$"
+        "[tmp][recTimestamp]" => "^\/Date\((?<[event][modified]>\d+)\)\/$"
+      }
+      break_on_match => false  #defining match twice in the same grok block overrides the first declaration so only one pattern is applied. We need to keep two grok or this setting as false
   }
   date {
     match => [ "[event][created]", "UNIX_MS" ]
     timezone => "GMT"
     locale => "en"
     target => "[event][created]"
-    tag_on_failure => "_dateparsefailure_es"
+    tag_on_failure => "_dateparsefailure_ec"
   }
   date {
     match => [ "[event][modified]", "UNIX_MS" ]


### PR DESCRIPTION
## Description
Changes:
security_bridge config file: defining match twice in the same grok block overrides the first declaration so only one pattern is applied. We need to keep two grok or set break_on_match to false. Because of this, event.created was not being mapped. 
workflow main.yaml: Use logstash 9.4.0 version and update actions/checkout and python-setup version to avoid node.js 20 deprecation warning. 

## Related Issues
Are there any Issues to this PR? 


## Todos
Are there any additional items that must be completed before this PR gets merged in?
- [ ] 
- [ ] 